### PR TITLE
KZL - 547 - Update validate specification signature

### DIFF
--- a/features/java/src/test/java/gradle/cucumber/Collectiondefs.java
+++ b/features/java/src/test/java/gradle/cucumber/Collectiondefs.java
@@ -117,7 +117,7 @@ public class Collectiondefs {
 
     @When("^I validate the specifications of \'([^\"]*)\'$")
     public void i_validate_the_specifications(String collection) throws Exception {
-        this.validationResponse = k.getCollection().validateSpecifications("{\""+world.index+"\":{\""+collection+"\":{\"strict\":true}}}");
+        this.validationResponse = k.getCollection().validateSpecifications(world.index, world.collection, "{\""+world.index+"\":{\""+collection+"\":{\"strict\":true}}}");
     }
 
     @Then("^they should be validated$")


### PR DESCRIPTION
## What does this PR do?

Before the method `validateSpecifications` didn't take an index an a collection in parameters and could be used for any collection.  
This PR change the signature to match the rest of the collection controller. The method now take an index and a collection in addition to the specifications for this collection.

I also modify the `updateSpecifications` method. The method was taking an index and collection in parameter but it didn't scope the specifications to the collection. 

Related PR: https://github.com/kuzzleio/sdk-javascript/pull/318, https://github.com/kuzzleio/sdk-go/pull/211, https://github.com/kuzzleio/sdk-c/pull/13, https://github.com/kuzzleio/sdk-cpp/pull/11, https://github.com/kuzzleio/sdk-java/pull/13, https://github.com/kuzzleio/documentation-V2/pull/51

### How should this be manually tested?

  - Step 1: Run Kuzzle Stack `./.ci/start_kuzzle.sh`
  - Step 2: Run tests: `docker run --rm -it -e ARCH="amd64" --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:openjdk8 bash -c "make clean all test"`