### PR TITLE
Don't ignore status attribut for Exceptions

### DIFF
--- a/swig/common.i
+++ b/swig/common.i
@@ -107,7 +107,9 @@
 
 %ignore *::error;
 %ignore *::stack;
-%ignore *::status;
+%ignore *_result::status;
+%ignore *_response::status;
+%ignore token_validity::status;
 
 
 %include "std_string.i"


### PR DESCRIPTION

## What does this PR do ?

In result structure like `subscribe_result` we have a `int status` used when Kuzzle respond with an error to throw the corresponding exception in CPP. As `error` and `stack`, we don't want these attributes to be wrapped with SWIG so we have an `%ignore` rule.  
But exceptions also have a `status` attribute and in this case we want it to be wrapped.

This PR ignore `status` only in result structure.

### How should this be manually tested?

  - Step 1 : Generate the SDK: `docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make clean all`
  - Step 2 : Check method presence: `javap -classpath build/kuzzlesdk-1.0.0-amd64.jar  io.kuzzle.sdk.KuzzleException | grep getStatus`
