### PR TITLE
Fix wrapping of options

### DIFF
--- a/swig/common.i
+++ b/swig/common.i
@@ -2,7 +2,7 @@
 %rename(TokenValidity) token_validity;
 %rename(AckResponse) ack_response;
 %rename(queueTTL) queue_ttl;
-%rename(Options, match="class") options;
+%rename(Options, match="class") s_options;
 %rename(QueryOptions) query_options;
 %rename(JsonObject) json_object;
 %rename(JsonResult) json_result;


### PR DESCRIPTION
## What does this PR do ?

Wrap `s_options` struct for Java.

### How should this be manually tested?

  - Step 1 : Build the SDK: `docker run --rm -it -e ARCH="amd64" --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:openjdk8 bash -c "make clean all"`
  - Step 2 : Check class: `javap -classpath build/kuzzlesdk-1.0.0-amd64.jar  io.kuzzle.sdk.Options`