### PR TITLE
Fix wrapping of options and room options

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,10 @@
   List any dependencies that are required for this change.
 -->
 
+<!-- Uncomment this section to link PR on other SDKs
+https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
+-->
+
 ### How should this be manually tested?
 
 <!--

--- a/swig/common.i
+++ b/swig/common.i
@@ -26,6 +26,9 @@
 %rename(SubscribeToSelf) subscribe_to_self;
 %rename(ValidationResponse) validation_response;
 %rename(UserRight) user_right;
+%rename(Options, match="class") s_options;
+%rename(RoomOptions, match="class") s_room_options;
+%rename(QueryOptions, match="class") s_query_options;
 
 // struct options
 %rename(queueMaxSize) queue_max_size;
@@ -76,8 +79,6 @@
 %rename(_collection, match="class") collection;
 %rename(_document, match="class") document;
 %rename(_server, match="class") server;
-%rename(Options, match="class") s_options;
-%rename(RoomOptions, match="class") s_room_options;
 
 %ignore *::error;
 %ignore *::stack;

--- a/swig/common.i
+++ b/swig/common.i
@@ -2,7 +2,6 @@
 %rename(TokenValidity) token_validity;
 %rename(AckResponse) ack_response;
 %rename(queueTTL) queue_ttl;
-%rename(Options, match="class") options;
 %rename(QueryOptions) query_options;
 %rename(JsonObject) json_object;
 %rename(JsonResult) json_result;
@@ -20,7 +19,6 @@
 %rename(DateResult) date_result;
 %rename(UserData) user_data;
 # %rename(User, match="class") user;
-%rename(RoomOptions) s_room_options;
 %rename(SearchFilters) search_filters;
 # %rename(SearchResult) search_result;
 %rename(NotificationResult) notification_result;
@@ -84,6 +82,8 @@
 %ignore *_result::status;
 %ignore *_response::status;
 %ignore token_validity::status;
+%ignore *::options;
+%ignore *::room_options;
 
 
 %include "std_string.i"
@@ -96,6 +96,8 @@
 #include "index.cpp"
 #include "server.cpp"
 #include "document.cpp"
+#include "options.cpp"
+#include "room_options.cpp"
 %}
 
 %ignore getListener;

--- a/swig/common.i
+++ b/swig/common.i
@@ -76,8 +76,8 @@
 %rename(_collection, match="class") collection;
 %rename(_document, match="class") document;
 %rename(_server, match="class") server;
-%rename(_options, match="class") options;
-%rename(_room_options, match="class") room_options;
+%rename(Options, match="class") s_options;
+%rename(RoomOptions, match="class") s_room_options;
 
 %ignore *::error;
 %ignore *::stack;
@@ -90,14 +90,13 @@
 
 
 %{
-#include "options.cpp"
-#include "room_options.cpp"
 #include "search_result.cpp"
 #include "collection.cpp"
 #include "auth.cpp"
 #include "index.cpp"
 #include "server.cpp"
 #include "document.cpp"
+#include "default_constructors.cpp"
 %}
 
 %ignore getListener;

--- a/swig/common.i
+++ b/swig/common.i
@@ -76,6 +76,8 @@
 %rename(_collection, match="class") collection;
 %rename(_document, match="class") document;
 %rename(_server, match="class") server;
+%rename(_options, match="class") options;
+%rename(_room_options, match="class") room_options;
 
 %ignore *::error;
 %ignore *::stack;
@@ -88,14 +90,14 @@
 
 
 %{
+#include "options.cpp"
+#include "room_options.cpp"
 #include "search_result.cpp"
 #include "collection.cpp"
 #include "auth.cpp"
 #include "index.cpp"
 #include "server.cpp"
 #include "document.cpp"
-#include "options.cpp"
-#include "room_options.cpp"
 %}
 
 %ignore getListener;

--- a/swig/common.i
+++ b/swig/common.i
@@ -82,8 +82,6 @@
 %ignore *_result::status;
 %ignore *_response::status;
 %ignore token_validity::status;
-%ignore *::options;
-%ignore *::room_options;
 
 
 %include "std_string.i"

--- a/swig/core.i
+++ b/swig/core.i
@@ -55,8 +55,6 @@ typedef long long time_t;
     }
 }
 
-%include "options.cpp"
-%include "room_options.cpp"
 %include "kuzzle.cpp"
 %include "collection.cpp"
 %include "document.cpp"
@@ -65,3 +63,4 @@ typedef long long time_t;
 %include "index.cpp"
 %include "server.cpp"
 %include "search_result.cpp"
+%include "default_constructors.cpp"

--- a/swig/core.i
+++ b/swig/core.i
@@ -55,6 +55,8 @@ typedef long long time_t;
     }
 }
 
+%include "options.cpp"
+%include "room_options.cpp"
 %include "kuzzle.cpp"
 %include "collection.cpp"
 %include "document.cpp"
@@ -63,5 +65,3 @@ typedef long long time_t;
 %include "index.cpp"
 %include "server.cpp"
 %include "search_result.cpp"
-%include "options.cpp"
-%include "room_options.cpp"

--- a/swig/core.i
+++ b/swig/core.i
@@ -63,5 +63,5 @@ typedef long long time_t;
 %include "index.cpp"
 %include "server.cpp"
 %include "search_result.cpp"
-#include "options.cpp"
-#include "room_options.cpp"
+%include "options.cpp"
+%include "room_options.cpp"

--- a/swig/core.i
+++ b/swig/core.i
@@ -63,3 +63,5 @@ typedef long long time_t;
 %include "index.cpp"
 %include "server.cpp"
 %include "search_result.cpp"
+#include "options.cpp"
+#include "room_options.cpp"

--- a/swig/kcore.i
+++ b/swig/kcore.i
@@ -1,7 +1,5 @@
 %module(directors="1") kuzzlesdk
 %{
-#include "options.hpp"
-#include "room_options.hpp"
 #include "exceptions.hpp"
 #include "event_emitter.hpp"
 #include "kuzzle.hpp"
@@ -18,8 +16,6 @@
 %define _Complex
 %enddef
 
-%include "options.hpp"
-%include "room_options.hpp"
 %include "kuzzlesdk.h"
 %include "kuzzle.h"
 %include "exceptions.hpp"

--- a/swig/kcore.i
+++ b/swig/kcore.i
@@ -30,5 +30,5 @@
 %include "document.hpp"
 %include "realtime.hpp"
 %include "auth.hpp"
-#include "options.hpp"
-#include "room_options.hpp"
+%include "options.hpp"
+%include "room_options.hpp"

--- a/swig/kcore.i
+++ b/swig/kcore.i
@@ -10,6 +10,8 @@
 #include "document.hpp"
 #include "realtime.hpp"
 #include "auth.hpp"
+#include "options.hpp"
+#include "room_options.hpp"
 #include <assert.h>
 %}
 
@@ -28,3 +30,5 @@
 %include "document.hpp"
 %include "realtime.hpp"
 %include "auth.hpp"
+#include "options.hpp"
+#include "room_options.hpp"

--- a/swig/kcore.i
+++ b/swig/kcore.i
@@ -1,5 +1,7 @@
 %module(directors="1") kuzzlesdk
 %{
+#include "options.hpp"
+#include "room_options.hpp"
 #include "exceptions.hpp"
 #include "event_emitter.hpp"
 #include "kuzzle.hpp"
@@ -10,14 +12,14 @@
 #include "document.hpp"
 #include "realtime.hpp"
 #include "auth.hpp"
-#include "options.hpp"
-#include "room_options.hpp"
 #include <assert.h>
 %}
 
 %define _Complex
 %enddef
 
+%include "options.hpp"
+%include "room_options.hpp"
 %include "kuzzlesdk.h"
 %include "kuzzle.h"
 %include "exceptions.hpp"
@@ -30,5 +32,3 @@
 %include "document.hpp"
 %include "realtime.hpp"
 %include "auth.hpp"
-%include "options.hpp"
-%include "room_options.hpp"

--- a/swig/typemap.i
+++ b/swig/typemap.i
@@ -157,3 +157,6 @@
 %typemap(javaout) kuzzleio::user_right** {
   return $jnicall;
 }
+
+%typemap(javabase) kuzzleio::Options "_options";
+%typemap(javabase) kuzzleio::RoomOptions "_room_options";

--- a/swig/typemap.i
+++ b/swig/typemap.i
@@ -157,6 +157,3 @@
 %typemap(javaout) kuzzleio::user_right** {
   return $jnicall;
 }
-
-%typemap(javabase) kuzzleio::Options "_options";
-%typemap(javabase) kuzzleio::RoomOptions "_room_options";


### PR DESCRIPTION
## What does this PR do ?

This pr allow usage of `Options`, `QueryOptions` and `RoomOptions` with default values

https://github.com/kuzzleio/sdk-cpp/pull/21 :arrow_left: :large_blue_circle:

### How should this be manually tested?

Save the following snippet as `Test.java` at the sdk root
```
import io.kuzzle.sdk.*;

public class Test {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
      Options options = new Options();
      System.out.println(options.getQueueTTL());

      RoomOptions roomOptions = new RoomOptions();
      System.out.println(roomOptions.getScope());
    }
}
```
Compile and execute this file with: `javac -cp ".:./build/kuzzlesdk-1.0.0-amd64.jar" Test.java && java -cp ".:./build/kuzzlesdk-1.0.0-amd64.jar" Test`
