### PR TITLE
Bugfix/specifications search result

### DIFF
--- a/swig/common.i
+++ b/swig/common.i
@@ -92,6 +92,7 @@
 
 %{
 #include "search_result.cpp"
+#include "specification_search_result.cpp"
 #include "collection.cpp"
 #include "auth.cpp"
 #include "index.cpp"

--- a/swig/core.i
+++ b/swig/core.i
@@ -63,4 +63,5 @@ typedef long long time_t;
 %include "index.cpp"
 %include "server.cpp"
 %include "search_result.cpp"
+%include "specification_search_result.cpp"
 %include "default_constructors.cpp"


### PR DESCRIPTION
## What does this PR do ?

This PR fixes missing includes related to `specification_search_result`, which are notably required to compile on MacOSX