### PR TITLE
Remove obsolete renames and typemaps

### DIFF
--- a/swig/common.i
+++ b/swig/common.i
@@ -1,6 +1,5 @@
 %rename(TokenValidity) token_validity;
 %rename(AckResponse) ack_response;
-%rename(queueTTL) queue_ttl;
 %rename(QueryOptions) query_options;
 %rename(JsonObject) json_object;
 %rename(JsonResult) json_result;
@@ -28,11 +27,10 @@
 %rename(QueryOptions, match="class") s_query_options;
 
 // struct options
+%rename(queueTTL) queue_ttl;
 %rename(queueMaxSize) queue_max_size;
-%rename(offlineMode) offline_mode;
 %rename(autoQueue) auto_queue;
 %rename(autoReconnect) auto_reconnect;
-%rename(autoReplay) auto_replay;
 %rename(autoReplay) auto_replay;
 %rename(autoResubscribe) auto_resubscribe;
 %rename(reconnectionDelay) reconnection_delay;

--- a/swig/typemap.i
+++ b/swig/typemap.i
@@ -47,50 +47,6 @@
 }
 %apply std::string * { std::string* };
 
-
-// const char** to String[]
-
-%typemap(jni) const char**, const char * const * "jobjectArray";
-%typemap(jtype) const char**, const char * const * "String[]";
-%typemap(jstype) const char**, const char * const * "String[]";
-
-%typemap(in) const char**, const char * const * %{
-  jobject fu = (jobject) jenv->GetObjectArrayElement($input, 0);
-
-  size_t size = jenv->GetArrayLength($input);
-  int i = 0;
-  char **res = (char**)malloc(sizeof(*res) * size + 1);
-  while(i < size) {
-    jobject fu = (jobject) jenv->GetObjectArrayElement($input, i);
-    res[i] = (char *)jenv->GetStringUTFChars(static_cast<jstring>(fu), 0);
-    i++;
-  }
-  res[i] = NULL;
-  $1 = res;
-%}
-
-%typemap(out) const char**, const char * const *  {
-  size_t count = 0;
-  const char **pos = const_cast<const char**>($1);
-  while(pos[++count]);
-
-  $result = JCALL3(NewObjectArray, jenv, count, JCALL1(FindClass, jenv, "java/lang/String"), NULL);
-  size_t idx = 0;
-  while (*pos) {
-    jobject str = JCALL1(NewStringUTF, jenv, *pos);
-    assert(idx < count);
-    JCALL3(SetObjectArrayElement, jenv, $result, idx++, str);
-    *pos++;
-  }
-}
-
-%typemap(javain) const char**, const char * const * "$javainput"
-%typemap(javaout) const char**, const char * const * {
-  return $jnicall;
-}
-
-// std::vector<std::shared_ptr<UserRight>> to UserRight[]
-
 %typemap(jni) std::vector<std::shared_ptr<kuzzleio::UserRight>> "jobjectArray";
 %typemap(jtype) std::vector<std::shared_ptr<kuzzleio::UserRight>> "UserRight[]";
 %typemap(jstype) std::vector<std::shared_ptr<kuzzleio::UserRight>> "UserRight[]";


### PR DESCRIPTION
# Description

Update SWIG templates:

* move the `queue_ttl` rename to its belonging section
* remove the duplicate `auto_replay` rename
* remove the obsolete `offline_mode` rename
* remove the obsolete `char**` typemaps: 
  1. these typemaps  consider these char arrays to be NULL-terminated, but they are not: the CGo SDK uses length-defined arrays instead
  2. there are no such types left in the C++ SDK anyway, they are all wrapped in C++ containers, to make SWIG wrapping easier