### PR TITLE
Add document:get

### DIFF
--- a/doc/3/controllers/document/get/index.md
+++ b/doc/3/controllers/document/get/index.md
@@ -1,0 +1,52 @@
+---
+code: true
+type: page
+title: get
+description: Gets a document
+---
+
+# get
+
+Gets a document.
+
+---
+
+## Arguments
+ 
+```java
+public CompletableFuture<ConcurrentHashMap<String, Object>> get(
+      final String index,
+      final String collection,
+      final String id)
+throws NotConnectedException, InternalException
+
+public CompletableFuture<ConcurrentHashMap<String, Object>> get(
+      final String index,
+      final String collection,
+      final String id
+      final Boolean queuable)
+throws NotConnectedException, InternalException
+```
+ 
+| Arguments          | Type                                         | Description                       |
+| ------------------ | -------------------------------------------- | --------------------------------- |
+| `index`            | <pre>String</pre>                            | Index                             |
+| `collection`       | <pre>String</pre>                            | Collection                        |
+| `id        `       | <pre>String</pre>                            | Document ID                       |
+| `queuable`         | <pre>Boolean</pre> (optional)                | If true, queues the request during downtime, until connected to Kuzzle again |
+
+---
+
+## Return
+
+A `ConcurrentHashMap` which has the following properties:
+
+| Property     | Type                         | Description                                                    |
+|------------- |----------------------------- |--------------------------------------------------------------- |
+| `_source`    | <pre>ConcurrentHashMap</pre> | Document content                |
+| `_id`        | <pre>String</pre>            | ID of the document                                     |
+| `_version`   | <pre>Integer</pre>           | Version of the document in the persistent data storage         |
+
+## Usage
+
+<<< ./snippets/get.java

--- a/doc/3/controllers/document/get/index.md
+++ b/doc/3/controllers/document/get/index.md
@@ -20,12 +20,6 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> get(
       final String id)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> get(
-      final String index,
-      final String collection,
-      final String id
-      final Boolean queuable)
-throws NotConnectedException, InternalException
 ```
  
 | Arguments          | Type                                         | Description                       |
@@ -33,7 +27,6 @@ throws NotConnectedException, InternalException
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
 | `id        `       | <pre>String</pre>                            | Document ID                       |
-| `queuable`         | <pre>Boolean</pre> (optional)                | If true, queues the request during downtime, until connected to Kuzzle again |
 
 ---
 

--- a/doc/3/controllers/document/get/snippets/get.java
+++ b/doc/3/controllers/document/get/snippets/get.java
@@ -1,0 +1,9 @@
+ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+    document.put("name", "John");
+
+    kuzzle.getDocumentController().create("nyc-open-data", "yellow-taxi", document, "some-id")
+    .get();
+
+    ConcurrentHashMap<String, Object> response =
+    kuzzle.getDocumentController().get("nyc-open-data", "yellow-taxi", "some-id")
+    .get();

--- a/doc/3/controllers/document/get/snippets/get.java
+++ b/doc/3/controllers/document/get/snippets/get.java
@@ -1,3 +1,4 @@
     ConcurrentHashMap<String, Object> response =
     kuzzle.getDocumentController().get("nyc-open-data", "yellow-taxi", "some-id")
     .get();
+    System.out.println(response);

--- a/doc/3/controllers/document/get/snippets/get.java
+++ b/doc/3/controllers/document/get/snippets/get.java
@@ -1,4 +1,16 @@
-    ConcurrentHashMap<String, Object> response =
+    ConcurrentHashMap<String, Object> result =
     kuzzle.getDocumentController().get("nyc-open-data", "yellow-taxi", "some-id")
     .get();
-    System.out.println(response);
+
+/*
+        {
+          _source=
+            {
+              key1=value1,
+              key2=value2,
+              _kuzzle_info= { createdAt=1582892127577, author=-1}
+            },
+          _id=some-id,
+          _version=1
+        }
+*/

--- a/doc/3/controllers/document/get/snippets/get.java
+++ b/doc/3/controllers/document/get/snippets/get.java
@@ -1,9 +1,3 @@
-ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
-    document.put("name", "John");
-
-    kuzzle.getDocumentController().create("nyc-open-data", "yellow-taxi", document, "some-id")
-    .get();
-
     ConcurrentHashMap<String, Object> response =
     kuzzle.getDocumentController().get("nyc-open-data", "yellow-taxi", "some-id")
     .get();

--- a/doc/3/controllers/document/get/snippets/get.test.yml
+++ b/doc/3/controllers/document/get/snippets/get.test.yml
@@ -1,0 +1,11 @@
+name: document#get
+description: Get a document from kuzzle
+hooks:
+  before: |
+    curl -XDELETE kuzzle:7512/nyc-open-data
+    curl -XPOST kuzzle:7512/nyc-open-data/_create
+    curl -XPUT kuzzle:7512/nyc-open-data/yellow-taxi
+    curl -XPOST -d '{"key1":"value1", "key2":"value2"}' -H "Content-Type: application/json" kuzzle:7512/nyc-open-data/yellow-taxi/some-id/_create
+  after:
+template: default
+expected: "_id: 'some-id'"

--- a/doc/3/controllers/document/get/snippets/get.test.yml
+++ b/doc/3/controllers/document/get/snippets/get.test.yml
@@ -8,4 +8,4 @@ hooks:
     curl -XPOST -d '{"key1":"value1", "key2":"value2"}' -H "Content-Type: application/json" kuzzle:7512/nyc-open-data/yellow-taxi/some-id/_create
   after:
 template: default
-expected: "_id: 'some-id'"
+expected: "_id=some-id"

--- a/doc/3/controllers/document/get/snippets/get.test.yml
+++ b/doc/3/controllers/document/get/snippets/get.test.yml
@@ -7,5 +7,5 @@ hooks:
     curl -XPUT kuzzle:7512/nyc-open-data/yellow-taxi
     curl -XPOST -d '{"key1":"value1", "key2":"value2"}' -H "Content-Type: application/json" kuzzle:7512/nyc-open-data/yellow-taxi/some-id/_create
   after:
-template: default
+template: print-result
 expected: "_id=some-id"

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -13,33 +13,33 @@ public class DocumentController extends BaseController {
     super(kuzzle);
   }
 
-  /**
-   * Gets a document in a given collection and index.
-   *
-   * @param index
-   * @param collection
-   * @param id
-   * @return a CompletableFuture
-   * @throws NotConnectedException
-   * @throws InternalException
-   */
-  public CompletableFuture<ConcurrentHashMap<String, Object>> get(
-      final String index,
-      final String collection,
-      final String id) throws NotConnectedException, InternalException {
-
-    final KuzzleMap query = new KuzzleMap();
-
-    query
-        .put("index", index)
-        .put("collection", collection)
-        .put("controller", "document")
-        .put("action", "get")
-        .put("_id",  id);
-
-    return kuzzle
-        .query(query)
-        .thenApplyAsync(
-            (response) -> (ConcurrentHashMap<String, Object>) response.result);
-  }
+//  /**
+//   * Gets a document in a given collection and index.
+//   *
+//   * @param index
+//   * @param collection
+//   * @param id
+//   * @return a CompletableFuture
+//   * @throws NotConnectedException
+//   * @throws InternalException
+//   */
+//  public CompletableFuture<ConcurrentHashMap<String, Object>> get(
+//      final String index,
+//      final String collection,
+//      final String id) throws NotConnectedException, InternalException {
+//
+//    final KuzzleMap query = new KuzzleMap();
+//
+//    query
+//        .put("index", index)
+//        .put("collection", collection)
+//        .put("controller", "document")
+//        .put("action", "get")
+//        .put("_id",  id);
+//
+//    return kuzzle
+//        .query(query)
+//        .thenApplyAsync(
+//            (response) -> (ConcurrentHashMap<String, Object>) response.result);
+//  }
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -1,0 +1,68 @@
+package io.kuzzle.sdk.API.Controllers;
+
+import com.sun.org.apache.xpath.internal.operations.Bool;
+import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
+import io.kuzzle.sdk.Exceptions.InternalException;
+import io.kuzzle.sdk.Exceptions.NotConnectedException;
+import io.kuzzle.sdk.Kuzzle;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.UUID;
+
+public class DocumentController extends BaseController {
+  public DocumentController(final Kuzzle kuzzle) {
+    super(kuzzle);
+  }
+
+  /**
+   * Gets a document in a given collection and index.
+   *
+   * @param index
+   * @param collection
+   * @param id
+   * @param queuable
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, Object>> get(
+      final String index,
+      final String collection,
+      final String id,
+      final Boolean queuable) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "document")
+        .put("action", "get")
+        .put("_id",  id)
+        .put("queuable", queuable);
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (ConcurrentHashMap<String, Object>) response.result);
+  }
+
+  /**
+   * Gets a document in a given collection and index.
+   *
+   * @param index
+   * @param collection
+   * @param id
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, Object>> get(
+      final String index,
+      final String collection,
+      final String id) throws NotConnectedException, InternalException {
+
+    return this.get(index, collection, id, false);
+  }
+}

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -1,6 +1,5 @@
 package io.kuzzle.sdk.API.Controllers;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
 import io.kuzzle.sdk.Exceptions.InternalException;
 import io.kuzzle.sdk.Exceptions.NotConnectedException;
@@ -8,44 +7,10 @@ import io.kuzzle.sdk.Kuzzle;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.UUID;
 
 public class DocumentController extends BaseController {
   public DocumentController(final Kuzzle kuzzle) {
     super(kuzzle);
-  }
-
-  /**
-   * Gets a document in a given collection and index.
-   *
-   * @param index
-   * @param collection
-   * @param id
-   * @param queuable
-   * @return a CompletableFuture
-   * @throws NotConnectedException
-   * @throws InternalException
-   */
-  public CompletableFuture<ConcurrentHashMap<String, Object>> get(
-      final String index,
-      final String collection,
-      final String id,
-      final Boolean queuable) throws NotConnectedException, InternalException {
-
-    final KuzzleMap query = new KuzzleMap();
-
-    query
-        .put("index", index)
-        .put("collection", collection)
-        .put("controller", "document")
-        .put("action", "get")
-        .put("_id",  id)
-        .put("queuable", queuable);
-
-    return kuzzle
-        .query(query)
-        .thenApplyAsync(
-            (response) -> (ConcurrentHashMap<String, Object>) response.result);
   }
 
   /**
@@ -63,6 +28,18 @@ public class DocumentController extends BaseController {
       final String collection,
       final String id) throws NotConnectedException, InternalException {
 
-    return this.get(index, collection, id, false);
+    final KuzzleMap query = new KuzzleMap();
+
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "document")
+        .put("action", "get")
+        .put("_id",  id);
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (ConcurrentHashMap<String, Object>) response.result);
   }
 }

--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -78,9 +78,6 @@ public class Kuzzle extends EventManager {
     return new AuthController(this);
   }
 
-  public DocumentController getDocumentController() {
-    return new DocumentController(this);
-  }
   /**
    * @return The DocumentController
    */

--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -1,5 +1,6 @@
 package io.kuzzle.sdk;
 
+import io.kuzzle.sdk.API.Controllers.DocumentController;
 import io.kuzzle.sdk.CoreClasses.Json.JsonSerializer;
 import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
 import io.kuzzle.sdk.API.Controllers.AuthController;
@@ -70,6 +71,9 @@ public class Kuzzle extends EventManager {
     return new AuthController(this);
   }
 
+  public DocumentController getDocumentController() {
+    return new DocumentController(this);
+  }
   /**
    * Initialize a new instance of Kuzzle
    *

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -1,0 +1,54 @@
+package io.kuzzle.test.API.Controllers.DocumentTest;
+
+import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
+import io.kuzzle.sdk.Exceptions.InternalException;
+import io.kuzzle.sdk.Exceptions.NotConnectedException;
+import io.kuzzle.sdk.Kuzzle;
+import io.kuzzle.sdk.Protocol.AbstractProtocol;
+import io.kuzzle.sdk.Protocol.ProtocolState;
+import io.kuzzle.sdk.Protocol.WebSocket;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class DocumentTest {
+
+  private AbstractProtocol networkProtocol = Mockito.mock(WebSocket.class);
+
+  @Test
+  public void getDocumentTest() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getDocumentController().get(index, collection, "some-id");
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+
+    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "get");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void getDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    kuzzleMock.getDocumentController().get(index, collection, "some-id");
+  }
+}

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -22,33 +22,33 @@ public class DocumentTest {
 
   private AbstractProtocol networkProtocol = Mockito.mock(WebSocket.class);
 
-  @Test
-  public void getDocumentTest() throws NotConnectedException, InternalException {
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
-
-    kuzzleMock.getDocumentController().get(index, collection, "some-id");
-    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
-
-    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
-    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "get");
-    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
-    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
-  }
-
-  @Test(expected = NotConnectedException.class)
-  public void getDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
-    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
-    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    kuzzleMock.getDocumentController().get(index, collection, "some-id");
-  }
+//  @Test
+//  public void getDocumentTest() throws NotConnectedException, InternalException {
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+//
+//    kuzzleMock.getDocumentController().get(index, collection, "some-id");
+//    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+//
+//    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+//    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "get");
+//    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+//    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+//  }
+//
+//  @Test(expected = NotConnectedException.class)
+//  public void getDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+//    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+//    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    kuzzleMock.getDocumentController().get(index, collection, "some-id");
+//  }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -54,7 +54,6 @@ public class DocumentTest {
 
    kuzzleMock.getDocumentController().get(index, collection, "some-id");
  }
-}
 
  @Test
  public void createOrReplaceDocumentTestA() throws NotConnectedException, InternalException {


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `document:get` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data` and a `yellow-taxi` collection in the admin console. Create a document with id `"some-id"`
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class getDocument {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            ConcurrentHashMap<String, Object> response =
            kuzzle.getDocumentController().get("nyc-open-data", "yellow-taxi", "some-id")
            .get();
            
           System.out.println(response);
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```
Check the printed response