### PR TITLE
Add document:delete

### DIFF
--- a/doc/3/controllers/document/delete/index.md
+++ b/doc/3/controllers/document/delete/index.md
@@ -1,29 +1,29 @@
 ---
 code: true
 type: page
-title: create
-description: Creates a new document
+title: delete
+description: Deletes a new document
 ---
 
-# create
+# delete
 
-Creates a new document in the provided index and collection.
+Deletes a document in the provided index and collection.
 
 ---
 
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
       final String index,
       final String collection,
-      final ConcurrentHashMap<String, Object> document)
+      final String id)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
       final String index,
       final String collection,
-      final ConcurrentHashMap<String, Object> document,
+      final String id,
       final ConcurrentHashMap<String, Object> options)
 throws NotConnectedException, InternalException
 ```
@@ -32,7 +32,7 @@ throws NotConnectedException, InternalException
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
-| `document`         | <pre>ConcurrentHashMap<String, Object></pre> | Content of the document to create |
+| `id      `         | <pre>String</pre>                            | Document ID |
 | `options`          | <pre>ConcurrentHashMap<String, Object></pre> | Optional parameters               |
 
 ---
@@ -41,19 +41,17 @@ throws NotConnectedException, InternalException
 
 | Arguments          | Type                                         | Description                       |
 | ------------------ | -------------------------------------------- | --------------------------------- |
-| `id`               | <pre>String</pre> (optional)                 | Document identifier. Auto-generated if not specified              |
-| `waitForRefresh`   | <pre>boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
+| `queuable`         | <pre>Boolean</pre> (optional)                | If true, queues the request during downtime, until connected to Kuzzle again   |
+| `waitForRefresh`   | <pre>Boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
 ## Return
 
-A `ConcurrentHashMap` which has the following properties:
+A `ConcurrentHashMap` which has the following property:
 
 | Property     | Type                         | Description                      |
 |------------- |----------------------------- |--------------------------------- |
-| `_source`    | <pre>ConcurrentHashMap</pre> | Created document                 |
-| `_id`        | <pre>String</pre>            | ID of the newly created document                       |
-| `_version`   | <pre>Integer</pre>           | Version of the document in the persistent data storage |
+| `_id`        | <pre>String</pre>            | ID of the deleted document                       |
 
 ## Usage
 
-<<< ./snippets/create.java
+<<< ./snippets/delete.java

--- a/doc/3/controllers/document/delete/index.md
+++ b/doc/3/controllers/document/delete/index.md
@@ -7,7 +7,7 @@ description: Deletes a document
 
 # delete
 
-Deletes a document in the provided index and collection.
+Deletes a document.
 
 ---
 

--- a/doc/3/controllers/document/delete/index.md
+++ b/doc/3/controllers/document/delete/index.md
@@ -2,7 +2,7 @@
 code: true
 type: page
 title: delete
-description: Deletes a new document
+description: Deletes a document
 ---
 
 # delete

--- a/doc/3/controllers/document/delete/index.md
+++ b/doc/3/controllers/document/delete/index.md
@@ -24,7 +24,7 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
       final String index,
       final String collection,
       final String id,
-      final ConcurrentHashMap<String, Object> options)
+      final Boolean waitForRefresh)
 throws NotConnectedException, InternalException
 ```
 
@@ -33,16 +33,9 @@ throws NotConnectedException, InternalException
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
 | `id      `         | <pre>String</pre>                            | Document ID |
-| `options`          | <pre>ConcurrentHashMap<String, Object></pre> | Optional parameters               |
+| `waitForRefresh`   | <pre>Boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
 ---
-
-### options
-
-| Arguments          | Type                                         | Description                       |
-| ------------------ | -------------------------------------------- | --------------------------------- |
-| `queuable`         | <pre>Boolean</pre> (optional)                | If true, queues the request during downtime, until connected to Kuzzle again   |
-| `waitForRefresh`   | <pre>Boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
 
 ## Return
 

--- a/doc/3/controllers/document/delete/index.md
+++ b/doc/3/controllers/document/delete/index.md
@@ -1,0 +1,59 @@
+---
+code: true
+type: page
+title: create
+description: Creates a new document
+---
+
+# create
+
+Creates a new document in the provided index and collection.
+
+---
+
+## Arguments
+
+```java
+public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> document)
+throws NotConnectedException, InternalException
+
+public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> document,
+      final ConcurrentHashMap<String, Object> options)
+throws NotConnectedException, InternalException
+```
+
+| Arguments          | Type                                         | Description                       |
+| ------------------ | -------------------------------------------- | --------------------------------- |
+| `index`            | <pre>String</pre>                            | Index                             |
+| `collection`       | <pre>String</pre>                            | Collection                        |
+| `document`         | <pre>ConcurrentHashMap<String, Object></pre> | Content of the document to create |
+| `options`          | <pre>ConcurrentHashMap<String, Object></pre> | Optional parameters               |
+
+---
+
+### options
+
+| Arguments          | Type                                         | Description                       |
+| ------------------ | -------------------------------------------- | --------------------------------- |
+| `id`               | <pre>String</pre> (optional)                 | Document identifier. Auto-generated if not specified              |
+| `waitForRefresh`   | <pre>boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
+
+## Return
+
+A `ConcurrentHashMap` which has the following properties:
+
+| Property     | Type                         | Description                      |
+|------------- |----------------------------- |--------------------------------- |
+| `_source`    | <pre>ConcurrentHashMap</pre> | Created document                 |
+| `_id`        | <pre>String</pre>            | ID of the newly created document                       |
+| `_version`   | <pre>Integer</pre>           | Version of the document in the persistent data storage |
+
+## Usage
+
+<<< ./snippets/create.java

--- a/doc/3/controllers/document/delete/snippets/delete.java
+++ b/doc/3/controllers/document/delete/snippets/delete.java
@@ -1,0 +1,3 @@
+
+  kuzzle.getDocumentController().delete("nyc-open-data", "yellow-taxi", "some_id")
+  .get();

--- a/doc/3/controllers/document/delete/snippets/delete.java
+++ b/doc/3/controllers/document/delete/snippets/delete.java
@@ -1,3 +1,3 @@
 
-  kuzzle.getDocumentController().delete("nyc-open-data", "yellow-taxi", "some_id")
+  kuzzle.getDocumentController().delete("nyc-open-data", "yellow-taxi", "some-id")
   .get();

--- a/doc/3/controllers/document/delete/snippets/delete.test.yml
+++ b/doc/3/controllers/document/delete/snippets/delete.test.yml
@@ -1,0 +1,11 @@
+name: document#create
+description: Creates a new document
+hooks:
+  before: |
+    curl -XDELETE kuzzle:7512/nyc-open-data
+    curl -XPOST kuzzle:7512/nyc-open-data/_create
+    curl -XPUT kuzzle:7512/nyc-open-data/yellow-taxi
+    curl -XPOST -d '{"key1":"value1", "key2":"value2"}' -H "Content-Type: application/json" kuzzle:7512/nyc-open-data/yellow-taxi/some-id/_create
+  after:
+template: default
+expected: Success

--- a/doc/3/controllers/document/delete/snippets/delete.test.yml
+++ b/doc/3/controllers/document/delete/snippets/delete.test.yml
@@ -1,5 +1,5 @@
-name: document#create
-description: Creates a new document
+name: document#delete
+description: deletes a document
 hooks:
   before: |
     curl -XDELETE kuzzle:7512/nyc-open-data

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -10,58 +10,58 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.UUID;
 
 public class DocumentController extends BaseController {
-  public DocumentController(final Kuzzle kuzzle) {
-    super(kuzzle);
-  }
+  // public DocumentController(final Kuzzle kuzzle) {
+  //   super(kuzzle);
+  // }
 
-  /**
-   * Deletes a document in a given collection and index.
-   *
-   * @param index
-   * @param collection
-   * @param id
-   * @param waitForRefresh
-   * @return a CompletableFuture
-   * @throws NotConnectedException
-   * @throws InternalException
-   */
-  public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
-      final String index,
-      final String collection,
-      final String id,
-      final Boolean waitForRefresh) throws NotConnectedException, InternalException {
+  // /**
+  //  * Deletes a document in a given collection and index.
+  //  *
+  //  * @param index
+  //  * @param collection
+  //  * @param id
+  //  * @param waitForRefresh
+  //  * @return a CompletableFuture
+  //  * @throws NotConnectedException
+  //  * @throws InternalException
+  //  */
+  // public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
+  //     final String index,
+  //     final String collection,
+  //     final String id,
+  //     final Boolean waitForRefresh) throws NotConnectedException, InternalException {
 
-    final KuzzleMap query = new KuzzleMap();
+  //   final KuzzleMap query = new KuzzleMap();
 
-    query
-        .put("index", index)
-        .put("collection", collection)
-        .put("controller", "document")
-        .put("action", "delete")
-        .put("_id",  id)
-        .put("waitForRefresh", waitForRefresh);
+  //   query
+  //       .put("index", index)
+  //       .put("collection", collection)
+  //       .put("controller", "document")
+  //       .put("action", "delete")
+  //       .put("_id",  id)
+  //       .put("waitForRefresh", waitForRefresh);
 
-    return kuzzle
-        .query(query)
-        .thenApplyAsync(
-            (response) -> (ConcurrentHashMap<String, Object>) response.result);
-  }
+  //   return kuzzle
+  //       .query(query)
+  //       .thenApplyAsync(
+  //           (response) -> (ConcurrentHashMap<String, Object>) response.result);
+  // }
 
-  /**
-   * Deletes a document in a given collection and index.
-   *
-   * @param index
-   * @param collection
-   * @param id
-   * @return a CompletableFuture
-   * @throws NotConnectedException
-   * @throws InternalException
-   */
-  public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
-      final String index,
-      final String collection,
-      final String id) throws NotConnectedException, InternalException {
+  // /**
+  //  * Deletes a document in a given collection and index.
+  //  *
+  //  * @param index
+  //  * @param collection
+  //  * @param id
+  //  * @return a CompletableFuture
+  //  * @throws NotConnectedException
+  //  * @throws InternalException
+  //  */
+  // public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
+  //     final String index,
+  //     final String collection,
+  //     final String id) throws NotConnectedException, InternalException {
 
-    return this.delete(index, collection, id, null);
-  }
+  //   return this.delete(index, collection, id, null);
+  // }
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -1,0 +1,72 @@
+package io.kuzzle.sdk.API.Controllers;
+
+import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
+import io.kuzzle.sdk.Exceptions.InternalException;
+import io.kuzzle.sdk.Exceptions.NotConnectedException;
+import io.kuzzle.sdk.Kuzzle;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.UUID;
+
+public class DocumentController extends BaseController {
+  public DocumentController(final Kuzzle kuzzle) {
+    super(kuzzle);
+  }
+
+  /**
+   * Deletes a document in a given collection and index.
+   *
+   * @param index
+   * @param collection
+   * @param id
+   * @param options
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
+      final String index,
+      final String collection,
+      final String id,
+      final ConcurrentHashMap<String, Object> options) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+    final KuzzleMap _options = KuzzleMap
+        .from(options);
+
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "document")
+        .put("action", "delete")
+        .put("_id",  id)
+        .put("queuable", _options.getBoolean("queuable"))
+        .put("waitForRefresh", _options.getBoolean("waitForRefresh"));
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (ConcurrentHashMap<String, Object>) response.result);
+  }
+
+  /**
+   * Deletes a document in a given collection and index.
+   *
+   * @param index
+   * @param collection
+   * @param id
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, Object>> delete(
+      final String index,
+      final String collection,
+      final String id) throws NotConnectedException, InternalException {
+
+    final ConcurrentHashMap<String, Object> options = new ConcurrentHashMap<>();
+    return this.delete(index, collection, id, options);
+  }
+
+}

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -62,6 +62,6 @@ public class DocumentController extends BaseController {
       final String collection,
       final String id) throws NotConnectedException, InternalException {
 
-    return this.delete(index, collection, id, false);
+    return this.delete(index, collection, id, null);
   }
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -20,7 +20,7 @@ public class DocumentController extends BaseController {
    * @param index
    * @param collection
    * @param id
-   * @param options
+   * @param waitForRefresh
    * @return a CompletableFuture
    * @throws NotConnectedException
    * @throws InternalException
@@ -29,11 +29,9 @@ public class DocumentController extends BaseController {
       final String index,
       final String collection,
       final String id,
-      final ConcurrentHashMap<String, Object> options) throws NotConnectedException, InternalException {
+      final Boolean waitForRefresh) throws NotConnectedException, InternalException {
 
     final KuzzleMap query = new KuzzleMap();
-    final KuzzleMap _options = KuzzleMap
-        .from(options);
 
     query
         .put("index", index)
@@ -41,8 +39,7 @@ public class DocumentController extends BaseController {
         .put("controller", "document")
         .put("action", "delete")
         .put("_id",  id)
-        .put("queuable", _options.getBoolean("queuable"))
-        .put("waitForRefresh", _options.getBoolean("waitForRefresh"));
+        .put("waitForRefresh", waitForRefresh);
 
     return kuzzle
         .query(query)
@@ -65,8 +62,6 @@ public class DocumentController extends BaseController {
       final String collection,
       final String id) throws NotConnectedException, InternalException {
 
-    final ConcurrentHashMap<String, Object> options = new ConcurrentHashMap<>();
-    return this.delete(index, collection, id, options);
+    return this.delete(index, collection, id, false);
   }
-
 }

--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -78,10 +78,6 @@ public class Kuzzle extends EventManager {
     return new AuthController(this);
   }
 
-  public DocumentController getDocumentController() {
-    return new DocumentController(this);
-  }
-
   /**
    * @return The IndexController
    */

--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -1,5 +1,6 @@
 package io.kuzzle.sdk;
 
+import io.kuzzle.sdk.API.Controllers.DocumentController;
 import io.kuzzle.sdk.CoreClasses.Json.JsonSerializer;
 import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
 import io.kuzzle.sdk.API.Controllers.AuthController;
@@ -68,6 +69,10 @@ public class Kuzzle extends EventManager {
 
   public AuthController getAuthController() {
     return new AuthController(this);
+  }
+
+  public DocumentController getDocumentController() {
+    return new DocumentController(this);
   }
 
   /**

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -22,53 +22,53 @@ public class DocumentTest {
 
   private AbstractProtocol networkProtocol = Mockito.mock(WebSocket.class);
 
-  @Test
-  public void deleteDocumentTestA() throws NotConnectedException, InternalException {
+  // @Test
+  // public void deleteDocumentTestA() throws NotConnectedException, InternalException {
 
-    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
+  //   Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+  //   String index = "nyc-open-data";
+  //   String collection = "yellow-taxi";
 
-    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+  //   ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
 
-    kuzzleMock.getDocumentController().delete(index, collection, "some-id", true);
-    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+  //   kuzzleMock.getDocumentController().delete(index, collection, "some-id", true);
+  //   Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
 
-    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
-    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "delete");
-    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
-    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
-    assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), true);
-  }
+  //   assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+  //   assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "delete");
+  //   assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+  //   assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+  //   assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), true);
+  // }
 
-  @Test
-  public void deleteDocumentTestB() throws NotConnectedException, InternalException {
+  // @Test
+  // public void deleteDocumentTestB() throws NotConnectedException, InternalException {
 
-    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
+  //   Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+  //   String index = "nyc-open-data";
+  //   String collection = "yellow-taxi";
 
-    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+  //   ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
 
-    kuzzleMock.getDocumentController().delete(index, collection, "some-id");
-    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+  //   kuzzleMock.getDocumentController().delete(index, collection, "some-id");
+  //   Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
 
-    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
-    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "delete");
-    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
-    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
-    assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), null);
-  }
+  //   assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+  //   assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "delete");
+  //   assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+  //   assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+  //   assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), null);
+  // }
 
-  @Test(expected = NotConnectedException.class)
-  public void deleteDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
-    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
-    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+  // @Test(expected = NotConnectedException.class)
+  // public void deleteDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+  //   AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+  //   Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
 
-    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
+  //   Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+  //   String index = "nyc-open-data";
+  //   String collection = "yellow-taxi";
 
-    kuzzleMock.getDocumentController().delete(index, collection, "some-id");
-  }
+  //   kuzzleMock.getDocumentController().delete(index, collection, "some-id");
+  // }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -23,7 +23,26 @@ public class DocumentTest {
   private AbstractProtocol networkProtocol = Mockito.mock(WebSocket.class);
 
   @Test
-  public void deleteDocumentTest() throws NotConnectedException, InternalException {
+  public void deleteDocumentTestA() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getDocumentController().delete(index, collection, "some-id", true);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+
+    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "delete");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+    assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), true);
+  }
+
+  @Test
+  public void deleteDocumentTestB() throws NotConnectedException, InternalException {
 
     Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
     String index = "nyc-open-data";
@@ -38,6 +57,7 @@ public class DocumentTest {
     assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "delete");
     assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
     assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+    assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), null);
   }
 
   @Test(expected = NotConnectedException.class)

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -1,0 +1,54 @@
+package io.kuzzle.test.API.Controllers.DocumentTest;
+
+import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
+import io.kuzzle.sdk.Exceptions.InternalException;
+import io.kuzzle.sdk.Exceptions.NotConnectedException;
+import io.kuzzle.sdk.Kuzzle;
+import io.kuzzle.sdk.Protocol.AbstractProtocol;
+import io.kuzzle.sdk.Protocol.ProtocolState;
+import io.kuzzle.sdk.Protocol.WebSocket;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class DocumentTest {
+
+  private AbstractProtocol networkProtocol = Mockito.mock(WebSocket.class);
+
+  @Test
+  public void deleteDocumentTest() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getDocumentController().delete(index, collection, "some-id");
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+
+    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "delete");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void deleteDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    kuzzleMock.getDocumentController().delete(index, collection, "some-id");
+  }
+}


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `document:delete` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data` and a `yellow-taxi` collection in the admin console. Create a document with id `some-id`
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class deleteDocument {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            ConcurrentHashMap<String, Object> response =
            kuzzle.getDocumentController().delete("nyc-open-data", "yellow-taxi", "some-id")
            .get();
            System.out.println(response);
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```
The document should be properly deleted with its id as request response