### PR TITLE
Add document:mGet

### DIFF
--- a/.ci/doc/templates/print-result-array.tpl.java
+++ b/.ci/doc/templates/print-result-array.tpl.java
@@ -1,11 +1,11 @@
 import io.kuzzle.sdk.Kuzzle;
-import java.util.ArrayList;
 import io.kuzzle.sdk.Protocol.WebSocket;
 import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
 import io.kuzzle.sdk.Options.KuzzleOptions;
-import java.util.concurrent.ConcurrentHashMap;
 import io.kuzzle.sdk.CoreClasses.Responses.Response;
-import io.kuzzle.sdk.Options.SubscribeOptions;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
 
 public class SnippetTest {
   private static Kuzzle kuzzle;
@@ -15,7 +15,9 @@ public class SnippetTest {
       kuzzle = new Kuzzle(new WebSocket("kuzzle"));
       kuzzle.connect();
       [snippet-code]
-      System.out.println("Success");
+      for (Object o : result.get("successes")) {
+        System.out.println(o);
+      }
     } catch (Exception e) {
       e.printStackTrace();
     } finally {

--- a/doc/3/controllers/document/m-get/index.md
+++ b/doc/3/controllers/document/m-get/index.md
@@ -14,7 +14,7 @@ Gets multiple documents.
 ## Arguments 
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mCreate(
+public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mGet(
       final String index,
       final String collection,
       final ArrayList<String> ids)
@@ -26,7 +26,7 @@ throws NotConnectedException, InternalException
 | ------------------ | ------------------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                                       | Index name                        |
 | `collection`       | <pre>String</pre>                                       | Collection name                   |
-| `ids`              | <pre>ArrayList<String></pre>                            | Document IDs |
+| `ids`              | <pre>ArrayList<String></pre>                            | Document IDs                      |
 ---
 
 ## Return

--- a/doc/3/controllers/document/m-get/index.md
+++ b/doc/3/controllers/document/m-get/index.md
@@ -1,0 +1,47 @@
+---
+code: true
+type: page
+title: mGet
+description: Gets multiple documents
+---
+
+# mGet
+
+Gets multiple documents.
+
+---
+
+## Arguments 
+
+```java
+public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mCreate(
+      final String index,
+      final String collection,
+      final ArrayList<String> ids)
+throws NotConnectedException, InternalException
+
+```
+
+| Arguments          | Type                                                    | Description                       |
+| ------------------ | ------------------------------------------------------- | --------------------------------- |
+| `index`            | <pre>String</pre>                                       | Index name                        |
+| `collection`       | <pre>String</pre>                                       | Collection name                   |
+| `ids`              | <pre>ArrayList<String></pre>                            | Document IDs |
+---
+
+## Return
+
+A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+Each created document is an object of the `successes` array with the following properties:
+
+| Property     | Type                                         | Description                      |
+|------------- |--------------------------------------------- |--------------------------------- |
+| `_source`    | <pre>ConcurrentHashMap<String, Object></pre> | Document content                 |
+| `_id`        | <pre>String</pre>                            | Document ID                      |
+| `_version`   | <pre>Integer</pre>                           | Version of the document in the persistent data storage |
+
+The `errors` array contain the IDs of not found documents.
+
+## Usage
+
+<<< ./snippets/m-get.java

--- a/doc/3/controllers/document/m-get/snippets/m-get.java
+++ b/doc/3/controllers/document/m-get/snippets/m-get.java
@@ -1,0 +1,37 @@
+    final ArrayList<String> ids = new ArrayList<>();
+    ids.add("some-id");
+    ids.add("some-id2");
+
+    ConcurrentHashMap<String, ArrayList<Object>> result = kuzzle.getDocumentController().mGet("nyc-open-data", "yellow-taxi", ids)
+    .get();
+
+/*
+    result =
+        {
+            successes=
+            [
+                {
+                    result=created,
+                    _source=
+                        {
+                            key=value,
+                            _kuzzle_info={createdAt=1582892842099, author=-1}
+                        },
+                    _id=some-id,
+                    _version=1
+                },
+                {
+                    result=created,
+                    _source=
+                        {
+                            key=value,
+                            _kuzzle_info={createdAt=1582892842099, author=-1}
+                        },
+                    _id=some-id2,
+                    _version=1
+                }
+            ],
+            errors=[]
+        }
+
+*/

--- a/doc/3/controllers/document/m-get/snippets/m-get.test.yml
+++ b/doc/3/controllers/document/m-get/snippets/m-get.test.yml
@@ -1,0 +1,14 @@
+name: document#mGet
+description: Get multiple documents
+hooks:
+  before: |
+    curl -XDELETE kuzzle:7512/nyc-open-data
+    curl -XPOST kuzzle:7512/nyc-open-data/_create
+    curl -XPUT kuzzle:7512/nyc-open-data/yellow-taxi
+    curl -XPOST -d '{"name":"John"}' -H "Content-Type: application/json" kuzzle:7512/nyc-open-data/yellow-taxi/some-id/_create
+    curl -XPOST -d '{"color":"purple"}' -H "Content-Type: application/json" kuzzle:7512/nyc-open-data/yellow-taxi/some-id2/_create
+  after:
+template: print-result-array
+expected:
+  - "id=some-id, _version=1"
+  - "id=some-id2, _version=1"

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -1,0 +1,46 @@
+package io.kuzzle.sdk.API.Controllers;
+
+import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
+import io.kuzzle.sdk.Exceptions.InternalException;
+import io.kuzzle.sdk.Exceptions.NotConnectedException;
+import io.kuzzle.sdk.Kuzzle;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DocumentController extends BaseController {
+  public DocumentController(final Kuzzle kuzzle) {
+    super(kuzzle);
+  }
+
+  /**
+   * Gets multiple documents in a given collection and index.
+   *
+   * @param index
+   * @param collection
+   * @param ids
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mGet(
+      final String index,
+      final String collection,
+      final ArrayList<String> ids) throws NotConnectedException, InternalException {
+
+
+    final KuzzleMap query = new KuzzleMap();
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "document")
+        .put("action", "mGet")
+        .put("body", new KuzzleMap().put("ids", ids));
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (ConcurrentHashMap<String, ArrayList<Object>>) response.result);
+  }
+}

--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -79,7 +79,7 @@ public class Kuzzle extends EventManager {
   }
 
   /**
-   * @return The AuthController
+   * @return The DocumentController
    */
   public DocumentController getDocumentController() {
     return new DocumentController(this);

--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -1,10 +1,11 @@
 package io.kuzzle.sdk;
 
+import io.kuzzle.sdk.API.Controllers.AuthController;
+import io.kuzzle.sdk.API.Controllers.DocumentController;
 import io.kuzzle.sdk.API.Controllers.IndexController;
 import io.kuzzle.sdk.API.Controllers.RealtimeController;
 import io.kuzzle.sdk.CoreClasses.Json.JsonSerializer;
 import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
-import io.kuzzle.sdk.API.Controllers.AuthController;
 import io.kuzzle.sdk.CoreClasses.Task;
 import io.kuzzle.sdk.Exceptions.*;
 import io.kuzzle.sdk.Options.KuzzleOptions;
@@ -75,6 +76,13 @@ public class Kuzzle extends EventManager {
    */
   public AuthController getAuthController() {
     return new AuthController(this);
+  }
+
+  /**
+   * @return The AuthController
+   */
+  public DocumentController getDocumentController() {
+    return new DocumentController(this);
   }
 
   /**

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -46,7 +46,7 @@ public class DocumentTest {
   }
 
   @Test(expected = NotConnectedException.class)
-  public void mCreateDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+  public void mGetDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
     AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
     Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
 

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -1,0 +1,63 @@
+package io.kuzzle.test.API.Controllers.DocumentTest;
+
+import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
+import io.kuzzle.sdk.Exceptions.InternalException;
+import io.kuzzle.sdk.Exceptions.NotConnectedException;
+import io.kuzzle.sdk.Kuzzle;
+import io.kuzzle.sdk.Protocol.AbstractProtocol;
+import io.kuzzle.sdk.Protocol.ProtocolState;
+import io.kuzzle.sdk.Protocol.WebSocket;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class DocumentTest {
+
+  private AbstractProtocol networkProtocol = Mockito.mock(WebSocket.class);
+
+  @Test
+  public void mGetDocumentTest() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    final ArrayList<String> ids = new ArrayList<>();
+    ids.add("some-id1");
+    ids.add("some-id2");
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getDocumentController().mGet(index, collection, ids);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "document");
+    assertEquals((arg.getValue()).getString("action"), "mGet");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals(((ArrayList<String>)(((KuzzleMap)(arg.getValue()).get("body"))).get("ids")).get(0), "some-id1");
+    assertEquals(((ArrayList<String>)(((KuzzleMap)(arg.getValue()).get("body"))).get("ids")).get(1), "some-id2");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void mCreateDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    final ArrayList<String> ids = new ArrayList<>();
+    ids.add("some-id1");
+    ids.add("some-id2");
+
+    kuzzleMock.getDocumentController().mGet(index, collection, ids);
+  }
+}


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `mGet` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data` and a `yellow-taxi` collection in the admin console. Create 2 documents with id `some-id1` and `some-id2`.
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class mGetDocument {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            final ArrayList<String> ids = new ArrayList<>();
            ids.add("some-id1");
            ids.add("some-id2");

            ConcurrentHashMap<String, ArrayList<Object>> result = 
            kuzzle.getDocumentController().mGet("nyc-open-data", "yellow-taxi", ids)
            .get();

            System.out.println(result);
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```

You should see the documents in your collection.
