### PR TITLE
Add document:mDelete

### DIFF
--- a/.ci/doc/templates/print-result-array.tpl.java
+++ b/.ci/doc/templates/print-result-array.tpl.java
@@ -8,14 +8,16 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.ArrayList;
 
 public class SnippetTest {
-
   private static Kuzzle kuzzle;
+
   public static void main(String[] argv) {
     try {
       kuzzle = new Kuzzle(new WebSocket("kuzzle"));
       kuzzle.connect();
       [snippet-code]
-      System.out.println(result.toString());
+      for (Object o : result.get("successes")) {
+        System.out.println(o);
+      }
     } catch (Exception e) {
       e.printStackTrace();
     } finally {

--- a/.ci/doc/templates/print-result.tpl.java
+++ b/.ci/doc/templates/print-result.tpl.java
@@ -8,8 +8,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.ArrayList;
 
 public class SnippetTest {
-
   private static Kuzzle kuzzle;
+
   public static void main(String[] argv) {
     try {
       kuzzle = new Kuzzle(new WebSocket("kuzzle"));

--- a/doc/3/controllers/document/m-delete/index.md
+++ b/doc/3/controllers/document/m-delete/index.md
@@ -1,0 +1,47 @@
+---
+code: true
+type: page
+title: mDelete
+description: Deletes multiple documents
+---
+
+# mDelete
+
+Delete multiple documents.
+
+---
+
+## Arguments 
+
+```java
+public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mDelete(
+      final String index,
+      final String collection,
+      final ArrayList<String> ids)
+throws NotConnectedException, InternalException
+
+```
+
+| Arguments          | Type                                                    | Description                       |
+| ------------------ | ------------------------------------------------------- | --------------------------------- |
+| `index`            | <pre>String</pre>                                       | Index name                        |
+| `collection`       | <pre>String</pre>                                       | Collection name                   |
+| `ids`              | <pre>ArrayList<String></pre>                            | Document IDs                      |
+---
+
+## Return
+
+A `ConcurrentHashMap<String, ArrayList<Object>>` which has a `successes` and `errors` `ArrayList<Object>`:
+The `successes` array contains the successfully deleted document IDs.
+
+Each deletion error is an object of the errors array with the following properties:
+
+| Property     | Type                                         | Description                      |
+|------------- |--------------------------------------------- |--------------------------------- |
+| `_id`        | <pre>String</pre>                            | Document ID                      |
+| `reason`     | <pre>ConcurrentHashMap<String, Object></pre> | Human readable reason            |
+| `status`     | <pre>Integer</pre>                           | HTTP status code |
+
+## Usage
+
+<<< ./snippets/m-delete.java

--- a/doc/3/controllers/document/m-delete/snippets/m-delete.java
+++ b/doc/3/controllers/document/m-delete/snippets/m-delete.java
@@ -1,0 +1,14 @@
+    final ArrayList<String> ids = new ArrayList<>();
+    ids.add("some-id");
+    ids.add("some-id2");
+
+    ConcurrentHashMap<String, ArrayList<Object>> result = kuzzle.getDocumentController().mDelete("nyc-open-data", "yellow-taxi", ids)
+    .get();
+/*
+    result =
+        {
+            successes=[some-id, some-id2],
+            errors=[]
+        }
+
+*/

--- a/doc/3/controllers/document/m-delete/snippets/m-delete.test.yml
+++ b/doc/3/controllers/document/m-delete/snippets/m-delete.test.yml
@@ -1,5 +1,5 @@
-name: document#mGet
-description: Get multiple documents
+name: document#mDelete
+description: Delete multiple documents
 hooks:
   before: |
     curl -XDELETE kuzzle:7512/nyc-open-data

--- a/doc/3/controllers/document/m-delete/snippets/m-delete.test.yml
+++ b/doc/3/controllers/document/m-delete/snippets/m-delete.test.yml
@@ -1,0 +1,14 @@
+name: document#mGet
+description: Get multiple documents
+hooks:
+  before: |
+    curl -XDELETE kuzzle:7512/nyc-open-data
+    curl -XPOST kuzzle:7512/nyc-open-data/_create
+    curl -XPUT kuzzle:7512/nyc-open-data/yellow-taxi
+    curl -XPOST -d '{"name":"John"}' -H "Content-Type: application/json" kuzzle:7512/nyc-open-data/yellow-taxi/some-id/_create
+    curl -XPOST -d '{"color":"purple"}' -H "Content-Type: application/json" kuzzle:7512/nyc-open-data/yellow-taxi/some-id2/_create
+  after:
+template: print-result-array
+expected:
+  - "some-id"
+  - "some-id2"

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -1,0 +1,67 @@
+package io.kuzzle.sdk.API.Controllers;
+
+import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
+import io.kuzzle.sdk.Exceptions.InternalException;
+import io.kuzzle.sdk.Exceptions.NotConnectedException;
+import io.kuzzle.sdk.Kuzzle;
+
+import java.util.ArrayList;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+public class DocumentController extends BaseController {
+  public DocumentController(final Kuzzle kuzzle) {
+    super(kuzzle);
+  }
+
+  /**
+   * Deletes multiple documents.
+   *
+   * @param index
+   * @param collection
+   * @param ids
+   * @param waitForRefresh
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mDelete(
+      final String index,
+      final String collection,
+      final ArrayList<String> ids,
+      final Boolean waitForRefresh) throws NotConnectedException, InternalException {
+
+
+    final KuzzleMap query = new KuzzleMap();
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "document")
+        .put("action", "mDelete")
+        .put("waitForRefresh", waitForRefresh)
+        .put("body", new KuzzleMap().put("ids", ids));
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (ConcurrentHashMap<String, ArrayList<Object>>) response.result);
+  }
+
+  /**
+   * Deletes multiple documents.
+   *
+   * @param index
+   * @param collection
+   * @param ids
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, ArrayList<Object>>> mDelete(
+      final String index,
+      final String collection,
+      final ArrayList<String> ids) throws NotConnectedException, InternalException {
+
+    return mDelete(index, collection, ids, null);
+  }
+}

--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -1,10 +1,11 @@
 package io.kuzzle.sdk;
 
+import io.kuzzle.sdk.API.Controllers.AuthController;
+import io.kuzzle.sdk.API.Controllers.DocumentController;
 import io.kuzzle.sdk.API.Controllers.IndexController;
 import io.kuzzle.sdk.API.Controllers.RealtimeController;
 import io.kuzzle.sdk.CoreClasses.Json.JsonSerializer;
 import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
-import io.kuzzle.sdk.API.Controllers.AuthController;
 import io.kuzzle.sdk.CoreClasses.Task;
 import io.kuzzle.sdk.Exceptions.*;
 import io.kuzzle.sdk.Options.KuzzleOptions;
@@ -75,6 +76,14 @@ public class Kuzzle extends EventManager {
    */
   public AuthController getAuthController() {
     return new AuthController(this);
+  }
+
+  /**
+   * @return The DocumentController
+   */
+  public DocumentController getDocumentController() {
+    return new DocumentController(this);
+
   }
 
   /**

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -1,0 +1,88 @@
+package io.kuzzle.test.API.Controllers.DocumentTest;
+
+import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
+import io.kuzzle.sdk.Exceptions.InternalException;
+import io.kuzzle.sdk.Exceptions.NotConnectedException;
+import io.kuzzle.sdk.Kuzzle;
+import io.kuzzle.sdk.Protocol.AbstractProtocol;
+import io.kuzzle.sdk.Protocol.ProtocolState;
+import io.kuzzle.sdk.Protocol.WebSocket;
+
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import java.util.ArrayList;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.*;
+
+public class DocumentTest {
+
+  private AbstractProtocol networkProtocol = Mockito.mock(WebSocket.class);
+
+  @Test
+  public void mDeleteDocumentTestA() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    final ArrayList<String> ids = new ArrayList<>();
+    ids.add("some-id1");
+    ids.add("some-id2");
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getDocumentController().mDelete(index, collection, ids);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "document");
+    assertEquals((arg.getValue()).getString("action"), "mDelete");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getBoolean("waitForRefresh"), null);
+    assertEquals(((ArrayList<String>)(((KuzzleMap)(arg.getValue()).get("body"))).get("ids")).get(0), "some-id1");
+    assertEquals(((ArrayList<String>)(((KuzzleMap)(arg.getValue()).get("body"))).get("ids")).get(1), "some-id2");
+  }
+
+  @Test
+  public void mDeleteDocumentTestB() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    final ArrayList<String> ids = new ArrayList<>();
+    ids.add("some-id1");
+    ids.add("some-id2");
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getDocumentController().mDelete(index, collection, ids, false);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "document");
+    assertEquals((arg.getValue()).getString("action"), "mDelete");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getBoolean("waitForRefresh"), false);
+    assertEquals(((ArrayList<String>)(((KuzzleMap)(arg.getValue()).get("body"))).get("ids")).get(0), "some-id1");
+    assertEquals(((ArrayList<String>)(((KuzzleMap)(arg.getValue()).get("body"))).get("ids")).get(1), "some-id2");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void mDeleteDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    final ArrayList<String> ids = new ArrayList<>();
+    ids.add("some-id1");
+    ids.add("some-id2");
+
+    kuzzleMock.getDocumentController().mDelete(index, collection, ids);
+  }
+
+}


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `mDelete` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data` and a `yellow-taxi` collection in the admin console. Create 2 documents with id `some-id1` and `some-id2`.
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class mDeleteDocument {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            final ArrayList<String> ids = new ArrayList<>();
            ids.add("some-id1");
            ids.add("some-id2");

            ConcurrentHashMap<String, ArrayList<Object>> result = 
            kuzzle.getDocumentController().mDelete("nyc-open-data", "yellow-taxi", ids)
            .get();

            System.out.println(result);
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```

You should see the documents in your collection.
