### PR TITLE
Add document:count

### DIFF
--- a/doc/3/controllers/document/count/index.md
+++ b/doc/3/controllers/document/count/index.md
@@ -1,0 +1,53 @@
+---
+code: true
+type: page
+title: count
+description: Counts documents in a collection.
+---
+
+# count
+
+Counts documents in a collection.
+
+A query can be provided to alter the count result, otherwise returns the total number of documents in the collection.
+
+Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/query-dsl.html) syntax.
+
+---
+
+## Arguments
+
+```java
+public CompletableFuture<Integer> count(
+      final String index,
+      final String collection)
+throws NotConnectedException, InternalException
+
+```
+
+```java
+public CompletableFuture<Integer> count(
+      final String index,
+      final String collection,
+      final ConcurrentHaspMap<String, Object> searchQuery)
+throws NotConnectedException, InternalException
+
+```
+
+---
+
+| Argument     | Type              | Description     |
+| ------------ | ----------------- | --------------- |
+| `index`      | <pre>string</pre> | Index name      |
+| `collection` | <pre>string</pre> | Collection name |
+| `query`      | <pre>object</pre> | Query to match  |
+
+---
+
+## Return
+
+Returns an Integer.
+
+## Usage
+
+<<< ./snippets/count.java

--- a/doc/3/controllers/document/count/index.md
+++ b/doc/3/controllers/document/count/index.md
@@ -36,11 +36,11 @@ throws NotConnectedException, InternalException
 
 ---
 
-| Argument     | Type              | Description     |
-| ------------ | ----------------- | --------------- |
-| `index`      | <pre>string</pre> | Index name      |
-| `collection` | <pre>string</pre> | Collection name |
-| `query`      | <pre>object</pre> | Query to match  |
+| Argument           | Type                                         | Description     |
+| ------------------ | -------------------------------------------- | --------------- |
+| `index`            | <pre>String</pre>                            | Index name      |
+| `collection`       | <pre>String</pre>                            | Collection name |
+| `searchQuery`      | <pre>ConcurrentHashMap<String, Object></pre> | Query to match  |
 
 ---
 

--- a/doc/3/controllers/document/count/index.md
+++ b/doc/3/controllers/document/count/index.md
@@ -11,7 +11,7 @@ Counts documents in a collection.
 
 A query can be provided to alter the count result, otherwise returns the total number of documents in the collection.
 
-Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/query-dsl.html) syntax.
+Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) syntax.
 
 ---
 

--- a/doc/3/controllers/document/count/snippets/count.java
+++ b/doc/3/controllers/document/count/snippets/count.java
@@ -2,4 +2,7 @@
     ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
     match.put("Hello", "Clarisse");
     searchQuery.put("match", match);
-    Integer result = kuzzle.getDocumentController().count("nyc-open-data", "yellow-taxi", searchQuery).get();
+    Integer result = kuzzle
+                      .getDocumentController()
+                      .count("nyc-open-data", "yellow-taxi", searchQuery)
+                      .get();

--- a/doc/3/controllers/document/count/snippets/count.java
+++ b/doc/3/controllers/document/count/snippets/count.java
@@ -1,0 +1,5 @@
+    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    match.put("Hello", "Clarisse");
+    searchQuery.put("match", match);
+    Integer result = kuzzle.getDocumentController().count("nyc-open-data", "yellow-taxi", searchQuery).get();

--- a/doc/3/controllers/document/count/snippets/count.test.yml
+++ b/doc/3/controllers/document/count/snippets/count.test.yml
@@ -1,0 +1,18 @@
+---
+name: document#count
+description: Counts documents matching the given query
+hooks:
+  before: |
+    curl -XDELETE kuzzle:7512/nyc-open-data
+    curl -XPOST kuzzle:7512/nyc-open-data/_create
+    curl -XPUT kuzzle:7512/nyc-open-data/yellow-taxi
+    for i in 1 2 3 4 5; do
+      curl -H "Content-type: application/json" -d '{"Hello": "Clarisse"}' kuzzle:7512/nyc-open-data/yellow-taxi/_create
+    done
+    for i in 1 2 3 4 5; do
+      curl -H "Content-type: application/json" -d '{}' kuzzle:7512/nyc-open-data/yellow-taxi/_create
+    done
+    curl -XPOST kuzzle:7512/nyc-open-data/yellow-taxi/_refresh
+  after:
+template: print-result
+expected: 5

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -1,5 +1,6 @@
 package io.kuzzle.sdk.API.Controllers;
 
+import com.google.gson.internal.LazilyParsedNumber;
 import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
 import io.kuzzle.sdk.Exceptions.InternalException;
 import io.kuzzle.sdk.Exceptions.NotConnectedException;
@@ -592,5 +593,52 @@ public class DocumentController extends BaseController {
       final ArrayList<ConcurrentHashMap<String, Object>> documents) throws NotConnectedException, InternalException {
 
     return this.mCreateOrReplace(index, collection, documents, null);
+  }
+
+  /**
+   * Counts documents in a collection.
+   *
+   * @param index
+   * @param collection
+   * @paran searchQuery
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<Integer> count(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> searchQuery) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "document")
+        .put("body", new KuzzleMap().put("query", searchQuery))
+        .put("action", "count");
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> ((LazilyParsedNumber) ((ConcurrentHashMap<String, Object>)response.result).get("count")).intValue());
+  }
+
+  /**
+   * Counts documents in a collection.
+   *
+   * @param index
+   * @param collection
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<Integer> count(
+      final String index,
+      final String collection) throws NotConnectedException, InternalException {
+
+    final ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+
+    return this.count(index, collection, searchQuery);
   }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -814,4 +814,59 @@ public class DocumentTest {
 
     kuzzleMock.getDocumentController().mCreateOrReplace(index, collection, documents);
   }
+
+  @Test
+  public void countDocumentTestA() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getDocumentController().count(index, collection);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "document");
+    assertEquals((arg.getValue()).getString("action"), "count");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+  }
+
+  @Test
+  public void countDocumentTestB() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    match.put("Hello", "Clarisse");
+    searchQuery.put("match", match);
+
+    kuzzleMock.getDocumentController().count(index, collection, searchQuery);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "document");
+    assertEquals((arg.getValue()).getString("action"), "count");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+    assertEquals(((ConcurrentHashMap<String, Object>)((ConcurrentHashMap<String, Object>)(((KuzzleMap)(arg.getValue()).get("body"))).get("query")).get("match")).get("Hello"), "Clarisse");
+
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void countDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    kuzzleMock.getDocumentController().count(index, collection);
+  }
 }


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `count` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data` and a `yellow-taxi` collection in the admin console. Create 5 documents with 3 of them containing a field `{"key":"value"}`.
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class countDocument {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
            ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
            match.put("key", "value");
            searchQuery.put("match", match);
            
            Integer result = kuzzle.getDocumentController().count("nyc-open-data", "yellow-taxi", searchQuery).get();
            System.out.println(result);
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```

You should have the right number returned (3 by passing searchQuery, 5 without)
