### PR TITLE
Add document:deleteByQuery

### DIFF
--- a/.ci/doc/templates/print-result-arraylist.tpl.java
+++ b/.ci/doc/templates/print-result-arraylist.tpl.java
@@ -1,0 +1,30 @@
+import io.kuzzle.sdk.Kuzzle;
+import io.kuzzle.sdk.Protocol.WebSocket;
+import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
+import io.kuzzle.sdk.Options.KuzzleOptions;
+import io.kuzzle.sdk.Options.SubscribeOptions;
+import io.kuzzle.sdk.CoreClasses.Responses.Response;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.ArrayList;
+
+public class SnippetTest {
+  private static Kuzzle kuzzle;
+
+  public static void main(String[] argv) {
+    try {
+      kuzzle = new Kuzzle(new WebSocket("kuzzle"));
+      kuzzle.connect();
+      [snippet-code]
+      for (Object o : result) {
+        System.out.println(o);
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    } finally {
+      if (kuzzle != null) {
+        kuzzle.disconnect();
+      }
+    }
+  }
+}

--- a/doc/3/controllers/document/delete-by-query/index.md
+++ b/doc/3/controllers/document/delete-by-query/index.md
@@ -1,0 +1,46 @@
+---
+code: true
+type: page
+title: deleteByQuery
+description: Delete documents matching query
+---
+
+# deleteByQuery
+
+Deletes documents matching the provided search query.
+
+Kuzzle uses the [ElasticSearch Query DSL](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/query-dsl.html) syntax.
+
+An empty or null query will match all documents in the collection.
+
+<br/>
+
+```java
+  public CompletableFuture<ArrayList<String>> deleteByQuery(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> searchQuery) throws NotConnectedException, InternalException
+
+  public CompletableFuture<ArrayList<String>> deleteByQuery(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> searchQuery,
+      final Boolean waitForRefresh) throws NotConnectedException, InternalException
+```
+
+| Argument           | Type                                         | Description     |
+| ------------------ | -------------------------------------------- | --------------- |
+| `index`            | <pre>String</pre>                            | Index name      |
+| `collection`       | <pre>String</pre>                            | Collection name |
+| `searchQuery`      | <pre>ConcurrentHashMap<String, Object></pre> | Query to match  |
+| `waitForRefresh`   | <pre>Boolean</pre> (optional)                | If set to `true`, Kuzzle will wait for the persistence layer to finish indexing|
+
+---
+
+## Returns
+
+Returns an `ArrayList<String>` containing the deleted document ids.
+
+## Usage
+
+<<< ./snippets/delete-by-query.js

--- a/doc/3/controllers/document/delete-by-query/snippets/delete-by-query.java
+++ b/doc/3/controllers/document/delete-by-query/snippets/delete-by-query.java
@@ -2,4 +2,7 @@
     ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
     match.put("capacity", 4);
     searchQuery.put("match", match);
-    ArrayList<String> result = kuzzle.getDocumentController().deleteByQuery("nyc-open-data", "yellow-taxi", searchQuery).get();
+    ArrayList<String> result = kuzzle
+      .getDocumentController()
+      .deleteByQuery("nyc-open-data", "yellow-taxi", searchQuery)
+      .get();

--- a/doc/3/controllers/document/delete-by-query/snippets/delete-by-query.java
+++ b/doc/3/controllers/document/delete-by-query/snippets/delete-by-query.java
@@ -1,0 +1,5 @@
+    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    match.put("capacity", 4);
+    searchQuery.put("match", match);
+    ArrayList<String> result = kuzzle.getDocumentController().deleteByQuery("nyc-open-data", "yellow-taxi", searchQuery).get();

--- a/doc/3/controllers/document/delete-by-query/snippets/delete-by-query.java
+++ b/doc/3/controllers/document/delete-by-query/snippets/delete-by-query.java
@@ -1,7 +1,9 @@
     ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> query = new ConcurrentHashMap<>();
     ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
     match.put("capacity", 4);
-    searchQuery.put("match", match);
+    query.put("match", match);
+    searchQuery.put("query", query);
     ArrayList<String> result = kuzzle
       .getDocumentController()
       .deleteByQuery("nyc-open-data", "yellow-taxi", searchQuery)

--- a/doc/3/controllers/document/delete-by-query/snippets/delete-by-query.test.yml
+++ b/doc/3/controllers/document/delete-by-query/snippets/delete-by-query.test.yml
@@ -1,0 +1,22 @@
+name: document#deleteByQuery
+description: Delete documents matching query
+hooks:
+  before: |
+    curl -XDELETE kuzzle:7512/nyc-open-data
+    curl -XPOST kuzzle:7512/nyc-open-data/_create
+    curl -XPUT kuzzle:7512/nyc-open-data/yellow-taxi
+    for i in  1 2 3 4 5; do
+      curl -H "Content-type: application/json" -d '{"capacity": 4}' kuzzle:7512/nyc-open-data/yellow-taxi/document_$i/_create
+    done
+    for i in  1 2 3 4 5; do
+      curl -H "Content-type: application/json" -d '{"capacity": 7}' kuzzle:7512/nyc-open-data/yellow-taxi/_create
+    done
+    curl -XPOST kuzzle:7512/nyc-open-data/_refresh
+  after:
+template: print-result-arraylist
+expected:
+  - "document_1"
+  - "document_2"
+  - "document_3"
+  - "document_4"
+  - "document_5"

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -593,4 +593,55 @@ public class DocumentController extends BaseController {
 
     return this.mCreateOrReplace(index, collection, documents, null);
   }
+
+  /**
+   * Deletes documents matching the provided search query.
+   *
+   * @param index
+   * @param collection
+   * @param searchQuery
+   * @param waitForRefresh
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ArrayList<String>> deleteByQuery(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> searchQuery,
+      final Boolean waitForRefresh) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "document")
+        .put("action", "deleteByQuery")
+        .put("body", new KuzzleMap().put("query", searchQuery))
+        .put("waitForRefresh", waitForRefresh);
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (ArrayList<String>)((ConcurrentHashMap<String, Object>) response.result).get("ids"));
+  }
+
+  /**
+   * Deletes documents matching the provided search query.
+   *
+   * @param index
+   * @param collection
+   * @param searchQuery
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ArrayList<String>> deleteByQuery(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> searchQuery) throws NotConnectedException, InternalException {
+
+    return this.deleteByQuery(index, collection, searchQuery, null);
+  }
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/DocumentController.java
@@ -594,54 +594,54 @@ public class DocumentController extends BaseController {
     return this.mCreateOrReplace(index, collection, documents, null);
   }
 
-  /**
-   * Deletes documents matching the provided search query.
-   *
-   * @param index
-   * @param collection
-   * @param searchQuery
-   * @param waitForRefresh
-   * @return a CompletableFuture
-   * @throws NotConnectedException
-   * @throws InternalException
-   */
-  public CompletableFuture<ArrayList<String>> deleteByQuery(
-      final String index,
-      final String collection,
-      final ConcurrentHashMap<String, Object> searchQuery,
-      final Boolean waitForRefresh) throws NotConnectedException, InternalException {
-
-    final KuzzleMap query = new KuzzleMap();
-
-    query
-        .put("index", index)
-        .put("collection", collection)
-        .put("controller", "document")
-        .put("action", "deleteByQuery")
-        .put("body", new KuzzleMap().put("query", searchQuery))
-        .put("waitForRefresh", waitForRefresh);
-
-    return kuzzle
-        .query(query)
-        .thenApplyAsync(
-            (response) -> (ArrayList<String>)((ConcurrentHashMap<String, Object>) response.result).get("ids"));
-  }
-
-  /**
-   * Deletes documents matching the provided search query.
-   *
-   * @param index
-   * @param collection
-   * @param searchQuery
-   * @return a CompletableFuture
-   * @throws NotConnectedException
-   * @throws InternalException
-   */
-  public CompletableFuture<ArrayList<String>> deleteByQuery(
-      final String index,
-      final String collection,
-      final ConcurrentHashMap<String, Object> searchQuery) throws NotConnectedException, InternalException {
-
-    return this.deleteByQuery(index, collection, searchQuery, null);
-  }
+//  /**
+//   * Deletes documents matching the provided search query.
+//   *
+//   * @param index
+//   * @param collection
+//   * @param searchQuery
+//   * @param waitForRefresh
+//   * @return a CompletableFuture
+//   * @throws NotConnectedException
+//   * @throws InternalException
+//   */
+//  public CompletableFuture<ArrayList<String>> deleteByQuery(
+//      final String index,
+//      final String collection,
+//      final ConcurrentHashMap<String, Object> searchQuery,
+//      final Boolean waitForRefresh) throws NotConnectedException, InternalException {
+//
+//    final KuzzleMap query = new KuzzleMap();
+//
+//    query
+//        .put("index", index)
+//        .put("collection", collection)
+//        .put("controller", "document")
+//        .put("action", "deleteByQuery")
+//        .put("body", new KuzzleMap(searchQuery))
+//        .put("waitForRefresh", waitForRefresh);
+//
+//    return kuzzle
+//        .query(query)
+//        .thenApplyAsync(
+//            (response) -> (ArrayList<String>)((ConcurrentHashMap<String, Object>) response.result).get("ids"));
+//  }
+//
+//  /**
+//   * Deletes documents matching the provided search query.
+//   *
+//   * @param index
+//   * @param collection
+//   * @param searchQuery
+//   * @return a CompletableFuture
+//   * @throws NotConnectedException
+//   * @throws InternalException
+//   */
+//  public CompletableFuture<ArrayList<String>> deleteByQuery(
+//      final String index,
+//      final String collection,
+//      final ConcurrentHashMap<String, Object> searchQuery) throws NotConnectedException, InternalException {
+//
+//    return this.deleteByQuery(index, collection, searchQuery, null);
+//  }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -815,68 +815,72 @@ public class DocumentTest {
     kuzzleMock.getDocumentController().mCreateOrReplace(index, collection, documents);
   }
 
-  @Test
-  public void deleteByQueryDocumentTestA() throws NotConnectedException, InternalException {
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
-    match.put("Hello", "Clarisse");
-    searchQuery.put("match", match);
-
-    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
-
-    kuzzleMock.getDocumentController().deleteByQuery(index, collection, searchQuery);
-    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
-
-    assertEquals((arg.getValue()).getString("controller"), "document");
-    assertEquals((arg.getValue()).getString("action"), "deleteByQuery");
-    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
-    assertEquals((arg.getValue()).getBoolean("waitForRefresh"), null);
-    assertEquals(((ConcurrentHashMap<String, Object>) ((ConcurrentHashMap<String, Object>) (((KuzzleMap) (arg.getValue()).get("body"))).get("query")).get("match")).get("Hello"), "Clarisse");
-  }
-
-  @Test
-  public void deleteByQueryDocumentTestB() throws NotConnectedException, InternalException {
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
-    match.put("Hello", "Clarisse");
-    searchQuery.put("match", match);
-
-    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
-
-    kuzzleMock.getDocumentController().deleteByQuery(index, collection, searchQuery, false);
-    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
-
-    assertEquals((arg.getValue()).getString("controller"), "document");
-    assertEquals((arg.getValue()).getString("action"), "deleteByQuery");
-    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
-    assertEquals((arg.getValue()).getBoolean("waitForRefresh"), false);
-    assertEquals(((ConcurrentHashMap<String, Object>) ((ConcurrentHashMap<String, Object>) (((KuzzleMap) (arg.getValue()).get("body"))).get("query")).get("match")).get("Hello"), "Clarisse");
-  }
-
-  @Test(expected = NotConnectedException.class)
-  public void deleteByQueryDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
-    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
-    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
-    match.put("Hello", "Clarisse");
-    searchQuery.put("match", match);
-
-    kuzzleMock.getDocumentController().deleteByQuery(index, collection, searchQuery);
-  }
+//  @Test
+//  public void deleteByQueryDocumentTestA() throws NotConnectedException, InternalException {
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+//    ConcurrentHashMap<String, Object> query = new ConcurrentHashMap<>();
+//    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+//    match.put("Hello", "Clarisse");
+//    query.put("match", match);
+//    searchQuery.put("query", query);
+//
+//    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+//
+//    kuzzleMock.getDocumentController().deleteByQuery(index, collection, searchQuery);
+//    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+//
+//    assertEquals((arg.getValue()).getString("controller"), "document");
+//    assertEquals((arg.getValue()).getString("action"), "deleteByQuery");
+//    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+//    assertEquals((arg.getValue()).getBoolean("waitForRefresh"), null);
+//    assertEquals(((ConcurrentHashMap<String, Object>) ((ConcurrentHashMap<String, Object>) (((KuzzleMap) (arg.getValue()).get("body"))).get("query")).get("match")).get("Hello"), "Clarisse");
+//  }
+//
+//  @Test
+//  public void deleteByQueryDocumentTestB() throws NotConnectedException, InternalException {
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+//    ConcurrentHashMap<String, Object> query = new ConcurrentHashMap<>();
+//    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+//    match.put("Hello", "Clarisse");
+//    query.put("match", match);
+//    searchQuery.put("query", query);
+//
+//    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+//
+//    kuzzleMock.getDocumentController().deleteByQuery(index, collection, searchQuery, false);
+//    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+//
+//    assertEquals((arg.getValue()).getString("controller"), "document");
+//    assertEquals((arg.getValue()).getString("action"), "deleteByQuery");
+//    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+//    assertEquals((arg.getValue()).getBoolean("waitForRefresh"), false);
+//    assertEquals(((ConcurrentHashMap<String, Object>) ((ConcurrentHashMap<String, Object>) (((KuzzleMap) (arg.getValue()).get("body"))).get("query")).get("match")).get("Hello"), "Clarisse");
+//  }
+//
+//  @Test(expected = NotConnectedException.class)
+//  public void deleteByQueryDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+//    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+//    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+//    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+//    match.put("Hello", "Clarisse");
+//    searchQuery.put("match", match);
+//
+//    kuzzleMock.getDocumentController().deleteByQuery(index, collection, searchQuery);
+//  }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/DocumentTest/DocumentTest.java
@@ -26,104 +26,104 @@ public class DocumentTest {
 
   private AbstractProtocol networkProtocol = Mockito.mock(WebSocket.class);
 
- @Test
- public void getDocumentTest() throws NotConnectedException, InternalException {
+  @Test
+  public void getDocumentTest() throws NotConnectedException, InternalException {
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
 
-   ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
 
-   kuzzleMock.getDocumentController().get(index, collection, "some-id");
-   Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+    kuzzleMock.getDocumentController().get(index, collection, "some-id");
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
 
-   assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "get");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
- }
+    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "get");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+  }
 
- @Test(expected = NotConnectedException.class)
- public void getDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
-   AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
-   Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+  @Test(expected = NotConnectedException.class)
+  public void getDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
 
-   kuzzleMock.getDocumentController().get(index, collection, "some-id");
- }
+    kuzzleMock.getDocumentController().get(index, collection, "some-id");
+  }
 
- @Test
- public void createOrReplaceDocumentTestA() throws NotConnectedException, InternalException {
+  @Test
+  public void createOrReplaceDocumentTestA() throws NotConnectedException, InternalException {
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
 
-   ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
-   document.put("name", "Yoann");
-   document.put("nickname", "El angel de la muerte que hace el JAVA");
+    ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+    document.put("name", "Yoann");
+    document.put("nickname", "El angel de la muerte que hace el JAVA");
 
-   ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
 
-   kuzzleMock.getDocumentController().createOrReplace(index, collection, "some-id", document, true);
-   Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+    kuzzleMock.getDocumentController().createOrReplace(index, collection, "some-id", document, true);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
 
-   assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "createOrReplace");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
-   assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), true);
-   assertEquals(((ConcurrentHashMap<String, Object>)(((KuzzleMap) arg.getValue()).get("body"))).get("name").toString(), "Yoann");
-   assertEquals(((ConcurrentHashMap<String, Object>)(((KuzzleMap) arg.getValue()).get("body"))).get("nickname").toString(), "El angel de la muerte que hace el JAVA");
- }
+    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "createOrReplace");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+    assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), true);
+    assertEquals(((ConcurrentHashMap<String, Object>) (((KuzzleMap) arg.getValue()).get("body"))).get("name").toString(), "Yoann");
+    assertEquals(((ConcurrentHashMap<String, Object>) (((KuzzleMap) arg.getValue()).get("body"))).get("nickname").toString(), "El angel de la muerte que hace el JAVA");
+  }
 
- @Test
- public void createOrReplaceDocumentTestB() throws NotConnectedException, InternalException {
+  @Test
+  public void createOrReplaceDocumentTestB() throws NotConnectedException, InternalException {
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
 
-   ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
-   document.put("name", "Yoann");
-   document.put("nickname", "El angel de la muerte que hace el JAVA");
+    ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+    document.put("name", "Yoann");
+    document.put("nickname", "El angel de la muerte que hace el JAVA");
 
-   ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
 
-   kuzzleMock.getDocumentController().createOrReplace(index, collection, "some-id", document);
-   Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+    kuzzleMock.getDocumentController().createOrReplace(index, collection, "some-id", document);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
 
-   assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "createOrReplace");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("waitForRefresh"), null);
-   assertEquals(((ConcurrentHashMap<String, Object>)(((KuzzleMap) arg.getValue()).get("body"))).get("name").toString(), "Yoann");
-   assertEquals(((ConcurrentHashMap<String, Object>)(((KuzzleMap) arg.getValue()).get("body"))).get("nickname").toString(), "El angel de la muerte que hace el JAVA");
- }
+    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "createOrReplace");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("waitForRefresh"), null);
+    assertEquals(((ConcurrentHashMap<String, Object>) (((KuzzleMap) arg.getValue()).get("body"))).get("name").toString(), "Yoann");
+    assertEquals(((ConcurrentHashMap<String, Object>) (((KuzzleMap) arg.getValue()).get("body"))).get("nickname").toString(), "El angel de la muerte que hace el JAVA");
+  }
 
- @Test(expected = NotConnectedException.class)
- public void createOrReplaceDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
-   AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
-   Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+  @Test(expected = NotConnectedException.class)
+  public void createOrReplaceDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
 
-   ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
-   document.put("name", "Yoann");
-   document.put("nickname", "El angel de la muerte que hace el JAVA");
+    ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+    document.put("name", "Yoann");
+    document.put("nickname", "El angel de la muerte que hace el JAVA");
 
-   kuzzleMock.getDocumentController().createOrReplace(index, collection, "some-id", document);
- }
+    kuzzleMock.getDocumentController().createOrReplace(index, collection, "some-id", document);
+  }
 
- @Test
- public void createDocumentTestA() throws NotConnectedException, InternalException {
+  @Test
+  public void createDocumentTestA() throws NotConnectedException, InternalException {
 
     Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
     String index = "nyc-open-data";
@@ -193,77 +193,77 @@ public class DocumentTest {
     kuzzleMock.getDocumentController().create(index, collection, document);
   }
 
- @Test
- public void udpateDocumentTestA() throws NotConnectedException, InternalException {
+  @Test
+  public void udpateDocumentTestA() throws NotConnectedException, InternalException {
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
 
-   ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
-   document.put("name", "Yoann");
+    ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+    document.put("name", "Yoann");
 
-   UpdateOptions options = new UpdateOptions();
-   options.setWaitForRefresh(false);
-   options.setSource(true);
-   options.setRetryOnConflict(1);
+    UpdateOptions options = new UpdateOptions();
+    options.setWaitForRefresh(false);
+    options.setSource(true);
+    options.setRetryOnConflict(1);
 
-   ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
 
-   kuzzleMock.getDocumentController().update(index, collection, "some-id", document, options);
-   Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+    kuzzleMock.getDocumentController().update(index, collection, "some-id", document, options);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
 
-   assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "update");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
-   assertEquals(((KuzzleMap) arg.getValue()).getNumber("retryOnConflict"), 1);
-   assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), false);
-   assertEquals(((KuzzleMap) arg.getValue()).getBoolean("source"), true);
-   assertEquals(((ConcurrentHashMap<String, Object>) (((KuzzleMap) arg.getValue()).get("body"))).get("name").toString(), "Yoann");
- }
+    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "update");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+    assertEquals(((KuzzleMap) arg.getValue()).getNumber("retryOnConflict"), 1);
+    assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), false);
+    assertEquals(((KuzzleMap) arg.getValue()).getBoolean("source"), true);
+    assertEquals(((ConcurrentHashMap<String, Object>) (((KuzzleMap) arg.getValue()).get("body"))).get("name").toString(), "Yoann");
+  }
 
- @Test
- public void udpateDocumentTestB() throws NotConnectedException, InternalException {
+  @Test
+  public void udpateDocumentTestB() throws NotConnectedException, InternalException {
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
 
-   ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
 
-   document.put("name", "Yoann");
-   ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
+    document.put("name", "Yoann");
+    ArgumentCaptor arg = ArgumentCaptor.forClass(KuzzleMap.class);
 
-   kuzzleMock.getDocumentController().update(index, collection, "some-id", document);
-   Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
+    kuzzleMock.getDocumentController().update(index, collection, "some-id", document);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query((KuzzleMap) arg.capture());
 
-   assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "update");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
-   assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
-   assertEquals(((KuzzleMap) arg.getValue()).getNumber("retryOnConflict"), null);
-   assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), null);
-   assertEquals(((KuzzleMap) arg.getValue()).getBoolean("source"), null);
-   assertEquals(((ConcurrentHashMap<String, Object>) (((KuzzleMap) arg.getValue()).get("body"))).get("name").toString(), "Yoann");
- }
+    assertEquals(((KuzzleMap) arg.getValue()).getString("controller"), "document");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("action"), "update");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals(((KuzzleMap) arg.getValue()).getString("_id"), "some-id");
+    assertEquals(((KuzzleMap) arg.getValue()).getNumber("retryOnConflict"), null);
+    assertEquals(((KuzzleMap) arg.getValue()).getBoolean("waitForRefresh"), null);
+    assertEquals(((KuzzleMap) arg.getValue()).getBoolean("source"), null);
+    assertEquals(((ConcurrentHashMap<String, Object>) (((KuzzleMap) arg.getValue()).get("body"))).get("name").toString(), "Yoann");
+  }
 
- @Test(expected = NotConnectedException.class)
- public void updateShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+  @Test(expected = NotConnectedException.class)
+  public void updateShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
 
-   AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
-   Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
-   String id = "some-id";
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+    String id = "some-id";
 
-   ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
-   document.put("name", "Yoann");
+    ConcurrentHashMap<String, Object> document = new ConcurrentHashMap<>();
+    document.put("name", "Yoann");
 
-   kuzzleMock.getDocumentController().update(index, collection, id, document);
- }
+    kuzzleMock.getDocumentController().update(index, collection, id, document);
+  }
 
   @Test
   public void mCreateDocumentTestA() throws NotConnectedException, InternalException {
@@ -298,8 +298,8 @@ public class DocumentTest {
     assertEquals((arg.getValue()).getString("action"), "mCreate");
     assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
     assertEquals((arg.getValue()).getBoolean("waitForRefresh"), null);
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
   }
 
   @Test
@@ -334,8 +334,8 @@ public class DocumentTest {
     assertEquals((arg.getValue()).getString("action"), "mCreate");
     assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
     assertEquals((arg.getValue()).getBoolean("waitForRefresh"), false);
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
   }
 
   @Test(expected = NotConnectedException.class)
@@ -615,8 +615,8 @@ public class DocumentTest {
     assertEquals((arg.getValue()).getString("action"), "mReplace");
     assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
     assertEquals((arg.getValue()).getBoolean("waitForRefresh"), null);
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
   }
 
   @Test
@@ -651,8 +651,8 @@ public class DocumentTest {
     assertEquals((arg.getValue()).getString("action"), "mReplace");
     assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
     assertEquals((arg.getValue()).getBoolean("waitForRefresh"), false);
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
   }
 
   @Test(expected = NotConnectedException.class)
@@ -713,7 +713,7 @@ public class DocumentTest {
 
     kuzzleMock.getDocumentController().exists(index, collection, "some-id");
   }
-  
+
   @Test
   public void mCreateOrReplaceDocumentTestA() throws NotConnectedException, InternalException {
 
@@ -747,8 +747,8 @@ public class DocumentTest {
     assertEquals((arg.getValue()).getString("action"), "mCreateOrReplace");
     assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
     assertEquals((arg.getValue()).getBoolean("waitForRefresh"), null);
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
   }
 
   @Test
@@ -783,8 +783,8 @@ public class DocumentTest {
     assertEquals((arg.getValue()).getString("action"), "mCreateOrReplace");
     assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
     assertEquals((arg.getValue()).getBoolean("waitForRefresh"), false);
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
-    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>)(((KuzzleMap)(arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(0).get("_id").toString(), "some-id1");
+    assertEquals(((ArrayList<ConcurrentHashMap<String, Object>>) (((KuzzleMap) (arg.getValue()).get("body"))).get("documents")).get(1).get("_id").toString(), "some-id2");
   }
 
   @Test(expected = NotConnectedException.class)
@@ -813,5 +813,70 @@ public class DocumentTest {
     documents.add(document2);
 
     kuzzleMock.getDocumentController().mCreateOrReplace(index, collection, documents);
+  }
+
+  @Test
+  public void deleteByQueryDocumentTestA() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    match.put("Hello", "Clarisse");
+    searchQuery.put("match", match);
+
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getDocumentController().deleteByQuery(index, collection, searchQuery);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "document");
+    assertEquals((arg.getValue()).getString("action"), "deleteByQuery");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getBoolean("waitForRefresh"), null);
+    assertEquals(((ConcurrentHashMap<String, Object>) ((ConcurrentHashMap<String, Object>) (((KuzzleMap) (arg.getValue()).get("body"))).get("query")).get("match")).get("Hello"), "Clarisse");
+  }
+
+  @Test
+  public void deleteByQueryDocumentTestB() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    match.put("Hello", "Clarisse");
+    searchQuery.put("match", match);
+
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getDocumentController().deleteByQuery(index, collection, searchQuery, false);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "document");
+    assertEquals((arg.getValue()).getString("action"), "deleteByQuery");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getBoolean("waitForRefresh"), false);
+    assertEquals(((ConcurrentHashMap<String, Object>) ((ConcurrentHashMap<String, Object>) (((KuzzleMap) (arg.getValue()).get("body"))).get("query")).get("match")).get("Hello"), "Clarisse");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void deleteByQueryDocumentShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
+    match.put("Hello", "Clarisse");
+    searchQuery.put("match", match);
+
+    kuzzleMock.getDocumentController().deleteByQuery(index, collection, searchQuery);
   }
 }


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `deleteByQuery` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data` and a `yellow-taxi` collection in the admin console. Create 5 documents with 3 containing field `{"key":"value"}`.
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class deleteByQueryDocument {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            ConcurrentHashMap<String, Object> searchQuery = new ConcurrentHashMap<>();
            ConcurrentHashMap<String, Object> match = new ConcurrentHashMap<>();
            match.put("key", "value");
            searchQuery.put("match", match);
            ArrayList<String> result = kuzzle.getDocumentController().deleteByQuery("nyc-open-data", "yellow-taxi", searchQuery).get();
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```

You should have an ArrayList<String> as result containing the deleted documents ids.
