### PR TITLE
Add Collection controller and collection:exists

### DIFF
--- a/doc/3/controllers/collection/exists/index.md
+++ b/doc/3/controllers/collection/exists/index.md
@@ -1,0 +1,39 @@
+---
+code: true
+type: page
+title: exists
+description: Checks if a collection exists
+---
+
+# exists
+
+Checks if a collection exists.
+
+---
+
+## Arguments
+
+```java
+public CompletableFuture<Boolean> exists(
+      final String index,
+      final String collection
+throws NotConnectedException, InternalException
+
+```
+
+---
+
+| Arguments          | Type                                         | Description                       |
+| ------------------ | -------------------------------------------- | --------------------------------- |
+| `index`            | <pre>String</pre>                            | Index                             |
+| `collection`       | <pre>String</pre>                            | Collection                        |
+
+---
+
+## Return
+
+Returns a boolean.
+
+## Usage
+
+<<< ./snippets/exists.java

--- a/doc/3/controllers/collection/exists/index.md
+++ b/doc/3/controllers/collection/exists/index.md
@@ -16,7 +16,7 @@ Checks if a collection exists.
 ```java
 public CompletableFuture<Boolean> exists(
       final String index,
-      final String collection
+      final String collection)
 throws NotConnectedException, InternalException
 
 ```

--- a/doc/3/controllers/collection/exists/snippets/exists.java
+++ b/doc/3/controllers/collection/exists/snippets/exists.java
@@ -1,0 +1,4 @@
+Boolean result = kuzzle
+    .getCollectionController()
+    .exists("nyc-open-data", "yellow-taxi")
+    .get();

--- a/doc/3/controllers/collection/exists/snippets/exists.test.yml
+++ b/doc/3/controllers/collection/exists/snippets/exists.test.yml
@@ -1,0 +1,10 @@
+name: collection#exists
+description: Check if collection exists
+hooks:
+  before: |
+    curl -XDELETE kuzzle:7512/nyc-open-data
+    curl -XPOST kuzzle:7512/nyc-open-data/_create
+    curl -XPUT kuzzle:7512/nyc-open-data/yellow-taxi
+  after:
+template: print-result
+expected: "true"

--- a/doc/3/controllers/collection/index.md
+++ b/doc/3/controllers/collection/index.md
@@ -1,0 +1,8 @@
+---
+code: true
+type: branch
+title: Collection
+description: Collection Controller
+---
+
+# Collection Controller

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -1,0 +1,41 @@
+package io.kuzzle.sdk.API.Controllers;
+
+import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
+import io.kuzzle.sdk.Exceptions.InternalException;
+import io.kuzzle.sdk.Exceptions.NotConnectedException;
+import io.kuzzle.sdk.Kuzzle;
+
+import java.util.concurrent.CompletableFuture;
+
+public class CollectionController extends BaseController {
+
+  public CollectionController(final Kuzzle kuzzle) {
+    super(kuzzle);
+  }
+
+  /**
+   * Tells if a collection exists in a given index.
+   *
+   * @param index
+   * @param collection
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<Boolean> exists(
+      final String index,
+      final String collection) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "collection")
+        .put("action", "exists");
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (Boolean) response.result);
+  }
+}

--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -82,7 +82,7 @@ public class Kuzzle extends EventManager {
   }
 
   /**
-   * @return The DocumentController
+   * @return The CollectionController
    */
   public CollectionController getCollectionController() {
     return new CollectionController(this);

--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -1,6 +1,7 @@
 package io.kuzzle.sdk;
 
 import io.kuzzle.sdk.API.Controllers.AuthController;
+import io.kuzzle.sdk.API.Controllers.CollectionController;
 import io.kuzzle.sdk.API.Controllers.DocumentController;
 import io.kuzzle.sdk.API.Controllers.IndexController;
 import io.kuzzle.sdk.API.Controllers.RealtimeController;
@@ -78,6 +79,13 @@ public class Kuzzle extends EventManager {
    */
   public AuthController getAuthController() {
     return new AuthController(this);
+  }
+
+  /**
+   * @return The DocumentController
+   */
+  public CollectionController getCollectionController() {
+    return new CollectionController(this);
   }
 
   /**

--- a/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
@@ -1,0 +1,52 @@
+package io.kuzzle.test.API.Controllers;
+
+import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
+import io.kuzzle.sdk.Exceptions.InternalException;
+import io.kuzzle.sdk.Exceptions.NotConnectedException;
+import io.kuzzle.sdk.Kuzzle;
+import io.kuzzle.sdk.Protocol.AbstractProtocol;
+import io.kuzzle.sdk.Protocol.ProtocolState;
+import io.kuzzle.sdk.Protocol.WebSocket;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.spy;
+
+public class CollectionTest {
+
+  private AbstractProtocol networkProtocol = Mockito.mock(WebSocket.class);
+
+  @Test
+  public void existsCollectionTest() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getCollectionController().exists(index, collection);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "collection");
+    assertEquals((arg.getValue()).getString("action"), "exists");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void existsCollectionShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    kuzzleMock.getCollectionController().exists(index, collection);
+  }
+}


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `collection:exists` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data` and a `yellow-taxi` collection.
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class existsCollection {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();
            kuzzle.getCollectionController().exists("nyc-open-data", "yellow-taxi")
            .get();
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```
