### PR TITLE
Add collection:create

### DIFF
--- a/doc/3/controllers/collection/create/index.md
+++ b/doc/3/controllers/collection/create/index.md
@@ -1,0 +1,68 @@
+---
+code: true
+type: page
+title: create
+description: Creates a new collection
+---
+
+# create
+
+Creates a new [collection](/core/2/guides/essentials/store-access-data) in Kuzzle via the persistence engine, in the provided index.
+
+You can also provide an optional data mapping that allow you to exploit the full capabilities of our
+persistent data storage layer, [ElasticSearch](https://www.elastic.co/elastic-stack) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/mapping.html)).
+
+This method will only update the mapping if the collection already exists.
+
+<br/>
+
+---
+
+## Arguments
+
+```java
+public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> mapping)
+throws NotConnectedException, InternalException
+
+public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+      final String index,
+      final String collection)
+throws NotConnectedException, InternalException
+```
+
+| Arguments          | Type                                         | Description                       |
+| ------------------ | -------------------------------------------- | --------------------------------- |
+| `index`            | <pre>String</pre>                            | Index                             |
+| `collection`       | <pre>String</pre>                            | Collection                        |
+| `mapping`          | <pre>object</pre>                            | Describes the data mapping to associate to the new collection, using Elasticsearch [mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/mapping.html) |
+
+---
+
+### mapping
+
+A `ConcurrentHashMap<String, Object>` representing the data mapping of the collection.
+
+The mapping must have a root field `properties` that contain the mapping definition:
+
+```java
+  ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
+  ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
+  ConcurrentHashMap<String, Object> field = new ConcurrentHashMap<>();
+
+  field.put("type", "keyword");
+  properties.put("field", field);
+  mapping.put("properties", properties);
+```
+
+More informations about database mappings [here](/core/2/guides/essentials/database-mappings).
+
+## Return
+
+A `ConcurrentHashMap` which has an `acknowledged` Boolean.
+
+## Usage
+
+<<< ./snippets/create.java

--- a/doc/3/controllers/collection/create/index.md
+++ b/doc/3/controllers/collection/create/index.md
@@ -21,13 +21,13 @@ This method will only update the mapping if the collection already exists.
 ## Arguments
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+public void create(
       final String index,
       final String collection,
       final ConcurrentHashMap<String, Object> mapping)
 throws NotConnectedException, InternalException
 
-public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+public void create(
       final String index,
       final String collection)
 throws NotConnectedException, InternalException
@@ -58,10 +58,6 @@ The mapping must have a root field `properties` that contain the mapping definit
 ```
 
 More information about database mappings [here](/core/2/guides/essentials/database-mappings).
-
-## Return
-
-A `ConcurrentHashMap` which has an `acknowledged` Boolean.
 
 ## Usage
 

--- a/doc/3/controllers/collection/create/index.md
+++ b/doc/3/controllers/collection/create/index.md
@@ -37,7 +37,7 @@ throws NotConnectedException, InternalException
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
-| `mapping`          | <pre>object</pre>                            | Describes the data mapping to associate to the new collection, using Elasticsearch [mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/7.3/mapping.html) |
+| `mapping`          | <pre>object</pre>                            | Describes the data mapping to associate to the new collection, using Elasticsearch [mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/mapping.html) |
 
 ---
 

--- a/doc/3/controllers/collection/create/index.md
+++ b/doc/3/controllers/collection/create/index.md
@@ -21,13 +21,13 @@ This method will only update the mapping if the collection already exists.
 ## Arguments
 
 ```java
-public void create(
+public CompletableFuture<Void> create(
       final String index,
       final String collection,
       final ConcurrentHashMap<String, Object> mapping)
 throws NotConnectedException, InternalException
 
-public void create(
+public CompletableFuture<Void> create(
       final String index,
       final String collection)
 throws NotConnectedException, InternalException

--- a/doc/3/controllers/collection/create/index.md
+++ b/doc/3/controllers/collection/create/index.md
@@ -9,7 +9,7 @@ description: Creates a new collection
 
 Creates a new [collection](/core/2/guides/essentials/store-access-data) in Kuzzle via the persistence engine, in the provided index.
 
-You can also provide an optional data mapping that allow you to exploit the full capabilities of our
+You can also provide an optional data mapping that allows you to exploit the full capabilities of our
 persistent data storage layer, [ElasticSearch](https://www.elastic.co/elastic-stack) (check here the [mapping capabilities of ElasticSearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/mapping.html)).
 
 This method will only update the mapping if the collection already exists.

--- a/doc/3/controllers/collection/create/index.md
+++ b/doc/3/controllers/collection/create/index.md
@@ -37,7 +37,7 @@ throws NotConnectedException, InternalException
 | ------------------ | -------------------------------------------- | --------------------------------- |
 | `index`            | <pre>String</pre>                            | Index                             |
 | `collection`       | <pre>String</pre>                            | Collection                        |
-| `mapping`          | <pre>object</pre>                            | Describes the data mapping to associate to the new collection, using Elasticsearch [mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/mapping.html) |
+| `mapping`          | <pre>ConcurrentHashMap<String, Object></pre> | Describes the data mapping to associate to the new collection, using Elasticsearch [mapping format](https://www.elastic.co/guide/en/elasticsearch/reference/7.4/mapping.html) |
 
 ---
 
@@ -57,7 +57,7 @@ The mapping must have a root field `properties` that contain the mapping definit
   mapping.put("properties", properties);
 ```
 
-More informations about database mappings [here](/core/2/guides/essentials/database-mappings).
+More information about database mappings [here](/core/2/guides/essentials/database-mappings).
 
 ## Return
 

--- a/doc/3/controllers/collection/create/snippets/create.java
+++ b/doc/3/controllers/collection/create/snippets/create.java
@@ -1,0 +1,10 @@
+  ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
+  ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
+  ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
+
+  license.put("type", "keyword");
+  properties.put("license", license);
+  mapping.put("properties", properties);
+
+  kuzzle.getCollectionController().create("nyc-open-data", "yellow-taxi", mapping)
+    .get();

--- a/doc/3/controllers/collection/create/snippets/create.test.yml
+++ b/doc/3/controllers/collection/create/snippets/create.test.yml
@@ -1,0 +1,9 @@
+name: collection#create
+description: Creates a new collection
+hooks:
+  before: |
+    curl -XDELETE kuzzle:7512/nyc-open-data
+    curl -XPOST kuzzle:7512/nyc-open-data/_create
+  after:
+template: default
+expected: Success

--- a/doc/3/controllers/document/m-update/snippets/m-update.test.yml
+++ b/doc/3/controllers/document/m-update/snippets/m-update.test.yml
@@ -10,5 +10,5 @@ hooks:
   after:
 template: print-result-array
 expected:
-  - "id=some-id, status=200"
-  - "id=some-id2, status=200"
+  - "id=some-id, _version=2, status=200"
+  - "id=some-id2, _version=2, status=200"

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -50,7 +50,7 @@ public class CollectionController extends BaseController {
    * @throws NotConnectedException
    * @throws InternalException
    */
-  public void create(
+  public CompletableFuture<Void> create(
       final String index,
       final String collection,
       final ConcurrentHashMap<String, Object> mappings) throws NotConnectedException, InternalException {
@@ -64,7 +64,9 @@ public class CollectionController extends BaseController {
         .put("action", "create")
         .put("body", mappings != null ? new KuzzleMap(mappings) : null);
 
-    kuzzle.query(query);
+    return kuzzle
+          .query(query)
+          .thenApplyAsync((response) -> null);
   }
 
   /**
@@ -76,11 +78,10 @@ public class CollectionController extends BaseController {
    * @throws NotConnectedException
    * @throws InternalException
    */
-  public void create(
+  public CompletableFuture<Void> create(
       final String index,
       final String collection) throws NotConnectedException, InternalException {
 
-    this.create(index, collection, null);
+    return this.create(index, collection, null);
   }
-
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -1,11 +1,14 @@
 package io.kuzzle.sdk.API.Controllers;
 
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
 import io.kuzzle.sdk.Exceptions.InternalException;
 import io.kuzzle.sdk.Exceptions.NotConnectedException;
 import io.kuzzle.sdk.Kuzzle;
+import io.kuzzle.sdk.Options.CreateOptions;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class CollectionController extends BaseController {
 
@@ -38,4 +41,51 @@ public class CollectionController extends BaseController {
         .thenApplyAsync(
             (response) -> (Boolean) response.result);
   }
+
+  /**
+   * Creates a collection in a given index.
+   *
+   * @param index
+   * @param collection
+   * @param mappings
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> mappings) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "collection")
+        .put("action", "create")
+        .put("body", mappings != null ? new KuzzleMap(mappings) : null);
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (ConcurrentHashMap<String, Object>) response.result);
+  }
+
+  /**
+   * Creates a collection in a given index.
+   *
+   * @param index
+   * @param collection
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+      final String index,
+      final String collection) throws NotConnectedException, InternalException {
+
+    return this.create(index, collection, null);
+  }
+
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -40,48 +40,48 @@ public class CollectionController extends BaseController {
             (response) -> (Boolean) response.result);
   }
 
-  /**
-   * Creates a collection in a given index.
-   *
-   * @param index
-   * @param collection
-   * @param mappings
-   * @return a CompletableFuture
-   * @throws NotConnectedException
-   * @throws InternalException
-   */
-  public CompletableFuture<Void> create(
-      final String index,
-      final String collection,
-      final ConcurrentHashMap<String, Object> mappings) throws NotConnectedException, InternalException {
-
-    final KuzzleMap query = new KuzzleMap();
-
-    query
-        .put("index", index)
-        .put("collection", collection)
-        .put("controller", "collection")
-        .put("action", "create")
-        .put("body", mappings != null ? new KuzzleMap(mappings) : null);
-
-    return kuzzle
-          .query(query)
-          .thenApplyAsync((response) -> null);
-  }
-
-  /**
-   * Creates a collection in a given index.
-   *
-   * @param index
-   * @param collection
-   * @return a CompletableFuture
-   * @throws NotConnectedException
-   * @throws InternalException
-   */
-  public CompletableFuture<Void> create(
-      final String index,
-      final String collection) throws NotConnectedException, InternalException {
-
-    return this.create(index, collection, null);
-  }
+//  /**
+//   * Creates a collection in a given index.
+//   *
+//   * @param index
+//   * @param collection
+//   * @param mappings
+//   * @return a CompletableFuture
+//   * @throws NotConnectedException
+//   * @throws InternalException
+//   */
+//  public CompletableFuture<Void> create(
+//      final String index,
+//      final String collection,
+//      final ConcurrentHashMap<String, Object> mappings) throws NotConnectedException, InternalException {
+//
+//    final KuzzleMap query = new KuzzleMap();
+//
+//    query
+//        .put("index", index)
+//        .put("collection", collection)
+//        .put("controller", "collection")
+//        .put("action", "create")
+//        .put("body", mappings != null ? new KuzzleMap(mappings) : null);
+//
+//    return kuzzle
+//          .query(query)
+//          .thenApplyAsync((response) -> null);
+//  }
+//
+//  /**
+//   * Creates a collection in a given index.
+//   *
+//   * @param index
+//   * @param collection
+//   * @return a CompletableFuture
+//   * @throws NotConnectedException
+//   * @throws InternalException
+//   */
+//  public CompletableFuture<Void> create(
+//      final String index,
+//      final String collection) throws NotConnectedException, InternalException {
+//
+//    return this.create(index, collection, null);
+//  }
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -50,7 +50,7 @@ public class CollectionController extends BaseController {
    * @throws NotConnectedException
    * @throws InternalException
    */
-  public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+  public void create(
       final String index,
       final String collection,
       final ConcurrentHashMap<String, Object> mappings) throws NotConnectedException, InternalException {
@@ -64,10 +64,7 @@ public class CollectionController extends BaseController {
         .put("action", "create")
         .put("body", mappings != null ? new KuzzleMap(mappings) : null);
 
-    return kuzzle
-        .query(query)
-        .thenApplyAsync(
-            (response) -> (ConcurrentHashMap<String, Object>) response.result);
+    kuzzle.query(query);
   }
 
   /**
@@ -79,11 +76,11 @@ public class CollectionController extends BaseController {
    * @throws NotConnectedException
    * @throws InternalException
    */
-  public CompletableFuture<ConcurrentHashMap<String, Object>> create(
+  public void create(
       final String index,
       final String collection) throws NotConnectedException, InternalException {
 
-    return this.create(index, collection, null);
+    this.create(index, collection, null);
   }
 
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -40,51 +40,51 @@ public class CollectionController extends BaseController {
             (response) -> (Boolean) response.result);
   }
 
- /**
-  * Creates a collection in a given index.
-  *
-  * @param index
-  * @param collection
-  * @param mappings
-  * @return a CompletableFuture
-  * @throws NotConnectedException
-  * @throws InternalException
-  */
- public CompletableFuture<Void> create(
-     final String index,
-     final String collection,
-     final ConcurrentHashMap<String, Object> mappings) throws NotConnectedException, InternalException {
+  /**
+   * Creates a collection in a given index.
+   *
+   * @param index
+   * @param collection
+   * @param mappings
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<Void> create(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> mappings) throws NotConnectedException, InternalException {
 
-   final KuzzleMap query = new KuzzleMap();
+    final KuzzleMap query = new KuzzleMap();
 
-   query
-       .put("index", index)
-       .put("collection", collection)
-       .put("controller", "collection")
-       .put("action", "create")
-       .put("body", mappings != null ? new KuzzleMap(mappings) : null);
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "collection")
+        .put("action", "create")
+        .put("body", mappings != null ? new KuzzleMap(mappings) : null);
 
-   return kuzzle
-         .query(query)
-         .thenApplyAsync((response) -> null);
- }
+    return kuzzle
+        .query(query)
+        .thenApplyAsync((response) -> null);
+  }
 
- /**
-  * Creates a collection in a given index.
-  *
-  * @param index
-  * @param collection
-  * @return a CompletableFuture
-  * @throws NotConnectedException
-  * @throws InternalException
-  */
- public CompletableFuture<Void> create(
-     final String index,
-     final String collection) throws NotConnectedException, InternalException {
+  /**
+   * Creates a collection in a given index.
+   *
+   * @param index
+   * @param collection
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<Void> create(
+      final String index,
+      final String collection) throws NotConnectedException, InternalException {
 
-   return this.create(index, collection, null);
- }
-  
+    return this.create(index, collection, null);
+  }
+
   /**
    * Get collection mapping
    *

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -1,11 +1,9 @@
 package io.kuzzle.sdk.API.Controllers;
 
-import com.sun.org.apache.xpath.internal.operations.Bool;
 import io.kuzzle.sdk.CoreClasses.Maps.KuzzleMap;
 import io.kuzzle.sdk.Exceptions.InternalException;
 import io.kuzzle.sdk.Exceptions.NotConnectedException;
 import io.kuzzle.sdk.Kuzzle;
-import io.kuzzle.sdk.Options.CreateOptions;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;

--- a/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
@@ -52,71 +52,71 @@ public class CollectionTest {
     kuzzleMock.getCollectionController().exists(index, collection);
   }
 
-@Test
- public void createCollectionTestA() throws NotConnectedException, InternalException {
+  @Test
+  public void createCollectionTestA() throws NotConnectedException, InternalException {
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
 
-   ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
 
-   kuzzleMock.getCollectionController().create(index, collection);
-   Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+    kuzzleMock.getCollectionController().create(index, collection);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
 
-   assertEquals((arg.getValue()).getString("controller"), "collection");
-   assertEquals((arg.getValue()).getString("action"), "create");
-   assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
-   assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
- }
+    assertEquals((arg.getValue()).getString("controller"), "collection");
+    assertEquals((arg.getValue()).getString("action"), "create");
+    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+  }
 
- @Test
- public void createCollectionTestB() throws NotConnectedException, InternalException {
+  @Test
+  public void createCollectionTestB() throws NotConnectedException, InternalException {
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
 
-   ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
 
-   ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
-   ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
-   ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
 
-   license.put("type", "keyword");
-   properties.put("license", license);
-   mapping.put("properties", properties);
+    license.put("type", "keyword");
+    properties.put("license", license);
+    mapping.put("properties", properties);
 
-   kuzzleMock.getCollectionController().create(index, collection, mapping);
-   Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+    kuzzleMock.getCollectionController().create(index, collection, mapping);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
 
-   assertEquals((arg.getValue()).getString("controller"), "collection");
-   assertEquals((arg.getValue()).getString("action"), "create");
-   assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
-   assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
-   assertEquals((
-       (ConcurrentHashMap<String, Object>) (
-           (ConcurrentHashMap<String, Object>) (
-               ((ConcurrentHashMap<String, Object>)
-                   ((arg.getValue())
-                       .get("body")))
-                   .get("properties")))
-           .get("license"))
-       .get("type").toString(), "keyword");
- }
+    assertEquals((arg.getValue()).getString("controller"), "collection");
+    assertEquals((arg.getValue()).getString("action"), "create");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+    assertEquals((
+        (ConcurrentHashMap<String, Object>) (
+            (ConcurrentHashMap<String, Object>) (
+                ((ConcurrentHashMap<String, Object>)
+                    ((arg.getValue())
+                        .get("body")))
+                    .get("properties")))
+            .get("license"))
+        .get("type").toString(), "keyword");
+  }
 
- @Test(expected = NotConnectedException.class)
- public void createCollectionThrowWhenNotConnected() throws NotConnectedException, InternalException {
+  @Test(expected = NotConnectedException.class)
+  public void createCollectionThrowWhenNotConnected() throws NotConnectedException, InternalException {
 
-   AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
-   Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
 
-   Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
-   String index = "nyc-open-data";
-   String collection = "yellow-taxi";
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
 
-   kuzzleMock.getCollectionController().create(index, collection);
- }
+    kuzzleMock.getCollectionController().create(index, collection);
+  }
 
   @Test
   public void getMappingCollectionTest() throws NotConnectedException, InternalException {

--- a/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
@@ -52,69 +52,69 @@ public class CollectionTest {
     kuzzleMock.getCollectionController().exists(index, collection);
   }
 
-  @Test
-  public void createCollectionTestA() throws NotConnectedException, InternalException {
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
-
-    kuzzleMock.getCollectionController().create(index, collection);
-    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
-
-    assertEquals((arg.getValue()).getString("controller"), "collection");
-    assertEquals((arg.getValue()).getString("action"), "create");
-    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
-    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
-  }
-
-  @Test
-  public void createCollectionTestB() throws NotConnectedException, InternalException {
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
-
-    ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
-    ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
-
-    license.put("type", "keyword");
-    properties.put("license", license);
-    mapping.put("properties", properties);
-
-    kuzzleMock.getCollectionController().create(index, collection, mapping);
-    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
-
-    assertEquals((arg.getValue()).getString("controller"), "collection");
-    assertEquals((arg.getValue()).getString("action"), "create");
-    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
-    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
-    assertEquals((
-        (ConcurrentHashMap<String, Object>) (
-            (ConcurrentHashMap<String, Object>) (
-                ((ConcurrentHashMap<String, Object>)
-                    ((arg.getValue())
-                        .get("body")))
-                    .get("properties")))
-            .get("license"))
-        .get("type").toString(), "keyword");
-  }
-
-  @Test(expected = NotConnectedException.class)
-  public void createCollectionThrowWhenNotConnected() throws NotConnectedException, InternalException {
-
-    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
-    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    kuzzleMock.getCollectionController().create(index, collection);
-  }
+//  @Test
+//  public void createCollectionTestA() throws NotConnectedException, InternalException {
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+//
+//    kuzzleMock.getCollectionController().create(index, collection);
+//    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+//
+//    assertEquals((arg.getValue()).getString("controller"), "collection");
+//    assertEquals((arg.getValue()).getString("action"), "create");
+//    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+//    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+//  }
+//
+//  @Test
+//  public void createCollectionTestB() throws NotConnectedException, InternalException {
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+//
+//    ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
+//    ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
+//    ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
+//
+//    license.put("type", "keyword");
+//    properties.put("license", license);
+//    mapping.put("properties", properties);
+//
+//    kuzzleMock.getCollectionController().create(index, collection, mapping);
+//    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+//
+//    assertEquals((arg.getValue()).getString("controller"), "collection");
+//    assertEquals((arg.getValue()).getString("action"), "create");
+//    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+//    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+//    assertEquals((
+//        (ConcurrentHashMap<String, Object>) (
+//            (ConcurrentHashMap<String, Object>) (
+//                ((ConcurrentHashMap<String, Object>)
+//                    ((arg.getValue())
+//                        .get("body")))
+//                    .get("properties")))
+//            .get("license"))
+//        .get("type").toString(), "keyword");
+//  }
+//
+//  @Test(expected = NotConnectedException.class)
+//  public void createCollectionThrowWhenNotConnected() throws NotConnectedException, InternalException {
+//
+//    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+//    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    kuzzleMock.getCollectionController().create(index, collection);
+//  }
 }


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `collection:create` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data`.
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class createCollection {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
            ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
            ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();

            license.put("type", "keyword");
            properties.put("license", license);
            mapping.put("properties", properties);

            ConcurrentHashMap<String, Object> re = kuzzle.getCollectionController().create("nyc-open-data", "yellow-taxi").get();
            
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```
