### PR TITLE
Add collection:truncate

### DIFF
--- a/doc/3/controllers/collection/truncate/index.md
+++ b/doc/3/controllers/collection/truncate/index.md
@@ -1,0 +1,33 @@
+---
+code: true
+type: page
+title: truncate
+description: Remove all documents from collection
+---
+
+# truncate
+
+Removes all documents from a collection, while keeping the associated mapping.
+
+<br/>
+
+```java
+public CompletableFuture<ConcurrentHashMap<String, Object>> truncate(
+      final String index,
+      final String collection) throws NotConnectedException, InternalException
+```
+
+<br/>
+
+| Arguments    | Type              | Description     |
+| ------------ | ----------------- | --------------- |
+| `index`      | <pre>String</pre> | Index name      |
+| `collection` | <pre>String</pre> | Collection name |
+
+## Returns
+
+A `ConcurrentHashMap` which has an `acknowledged` Boolean.
+
+## Usage
+
+<<< ./snippets/truncate.js

--- a/doc/3/controllers/collection/truncate/index.md
+++ b/doc/3/controllers/collection/truncate/index.md
@@ -7,7 +7,7 @@ description: Remove all documents from a collection
 
 # truncate
 
-Removes all documents from a collection, while keeping the associated mapping.
+Removes all documents from a collection, while keeping the associated mappings.
 
 <br/>
 

--- a/doc/3/controllers/collection/truncate/index.md
+++ b/doc/3/controllers/collection/truncate/index.md
@@ -2,7 +2,7 @@
 code: true
 type: page
 title: truncate
-description: Remove all documents from collection
+description: Remove all documents from a collection
 ---
 
 # truncate

--- a/doc/3/controllers/collection/truncate/index.md
+++ b/doc/3/controllers/collection/truncate/index.md
@@ -12,7 +12,7 @@ Removes all documents from a collection, while keeping the associated mappings.
 <br/>
 
 ```java
-public CompletableFuture<ConcurrentHashMap<String, Object>> truncate(
+public CompletableFuture<Void> truncate(
       final String index,
       final String collection) throws NotConnectedException, InternalException
 ```
@@ -23,10 +23,6 @@ public CompletableFuture<ConcurrentHashMap<String, Object>> truncate(
 | ------------ | ----------------- | --------------- |
 | `index`      | <pre>String</pre> | Index name      |
 | `collection` | <pre>String</pre> | Collection name |
-
-## Returns
-
-A `ConcurrentHashMap` which has an `acknowledged` Boolean.
 
 ## Usage
 

--- a/doc/3/controllers/collection/truncate/snippets/truncate.java
+++ b/doc/3/controllers/collection/truncate/snippets/truncate.java
@@ -1,0 +1,1 @@
+    kuzzle.getCollectionController().truncate("nyc-open-data", "yellow-taxi").get();

--- a/doc/3/controllers/collection/truncate/snippets/truncate.test.yml
+++ b/doc/3/controllers/collection/truncate/snippets/truncate.test.yml
@@ -1,0 +1,7 @@
+name: collection#truncate
+description: Remove all documents from collection
+hooks:
+  before: curl -X POST kuzzle:7512/nyc-open-data/_create && curl -X PUT kuzzle:7512/nyc-open-data/yellow-taxi
+  after:
+template: default
+expected: Success

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -49,7 +49,7 @@ public class CollectionController extends BaseController {
    * @throws NotConnectedException
    * @throws InternalException
    */
-  public CompletableFuture<ConcurrentHashMap<String, Object>> truncate(
+  public CompletableFuture<Void> truncate(
       final String index,
       final String collection) throws NotConnectedException, InternalException {
 
@@ -63,6 +63,6 @@ public class CollectionController extends BaseController {
     return kuzzle
         .query(query)
         .thenApplyAsync(
-            (response) -> (ConcurrentHashMap<String, Object>) response.result);
+            (response) -> (null));
   }
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -39,29 +39,29 @@ public class CollectionController extends BaseController {
             (response) -> (Boolean) response.result);
   }
 
-  /**
-   * Removes all documents from collection.
-   *
-   * @param index
-   * @param collection
-   * @return a CompletableFuture
-   * @throws NotConnectedException
-   * @throws InternalException
-   */
-  public CompletableFuture<Void> truncate(
-      final String index,
-      final String collection) throws NotConnectedException, InternalException {
-
-    final KuzzleMap query = new KuzzleMap();
-    query
-        .put("index", index)
-        .put("collection", collection)
-        .put("controller", "collection")
-        .put("action", "truncate");
-
-    return kuzzle
-        .query(query)
-        .thenApplyAsync(
-            (response) -> (null));
-  }
+//  /**
+//   * Removes all documents from collection.
+//   *
+//   * @param index
+//   * @param collection
+//   * @return a CompletableFuture
+//   * @throws NotConnectedException
+//   * @throws InternalException
+//   */
+//  public CompletableFuture<Void> truncate(
+//      final String index,
+//      final String collection) throws NotConnectedException, InternalException {
+//
+//    final KuzzleMap query = new KuzzleMap();
+//    query
+//        .put("index", index)
+//        .put("collection", collection)
+//        .put("controller", "collection")
+//        .put("action", "truncate");
+//
+//    return kuzzle
+//        .query(query)
+//        .thenApplyAsync(
+//            (response) -> (null));
+//  }
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -5,7 +5,9 @@ import io.kuzzle.sdk.Exceptions.InternalException;
 import io.kuzzle.sdk.Exceptions.NotConnectedException;
 import io.kuzzle.sdk.Kuzzle;
 
+import java.util.ConcurrentModificationException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class CollectionController extends BaseController {
 
@@ -37,5 +39,31 @@ public class CollectionController extends BaseController {
         .query(query)
         .thenApplyAsync(
             (response) -> (Boolean) response.result);
+  }
+
+  /**
+   * Deletes every collections documents.
+   *
+   * @param index
+   * @param collection
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, Object>> truncate(
+      final String index,
+      final String collection) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "collection")
+        .put("action", "truncate");
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (ConcurrentHashMap<String, Object>) response.result);
   }
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -5,7 +5,6 @@ import io.kuzzle.sdk.Exceptions.InternalException;
 import io.kuzzle.sdk.Exceptions.NotConnectedException;
 import io.kuzzle.sdk.Kuzzle;
 
-import java.util.ConcurrentModificationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -42,7 +41,7 @@ public class CollectionController extends BaseController {
   }
 
   /**
-   * Deletes every collections documents.
+   * Removes all documents from collection.
    *
    * @param index
    * @param collection

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -6,7 +6,6 @@ import io.kuzzle.sdk.Exceptions.NotConnectedException;
 import io.kuzzle.sdk.Kuzzle;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
 
 public class CollectionController extends BaseController {
 

--- a/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
@@ -50,33 +50,33 @@ public class CollectionTest {
     kuzzleMock.getCollectionController().exists(index, collection);
   }
 
-  @Test
-  public void truncateCollectionTest() throws NotConnectedException, InternalException {
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
-
-    kuzzleMock.getCollectionController().truncate(index, collection);
-    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
-
-    assertEquals((arg.getValue()).getString("controller"), "collection");
-    assertEquals((arg.getValue()).getString("action"), "truncate");
-    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
-    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
-  }
-
-  @Test(expected = NotConnectedException.class)
-  public void truncateCollectionShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
-    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
-    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    kuzzleMock.getCollectionController().truncate(index, collection);
-  }
+//  @Test
+//  public void truncateCollectionTest() throws NotConnectedException, InternalException {
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+//
+//    kuzzleMock.getCollectionController().truncate(index, collection);
+//    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+//
+//    assertEquals((arg.getValue()).getString("controller"), "collection");
+//    assertEquals((arg.getValue()).getString("action"), "truncate");
+//    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+//    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+//  }
+//
+//  @Test(expected = NotConnectedException.class)
+//  public void truncateCollectionShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+//    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+//    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    kuzzleMock.getCollectionController().truncate(index, collection);
+//  }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
@@ -49,4 +49,34 @@ public class CollectionTest {
 
     kuzzleMock.getCollectionController().exists(index, collection);
   }
+
+  @Test
+  public void truncateCollectionTest() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getCollectionController().truncate(index, collection);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "collection");
+    assertEquals((arg.getValue()).getString("action"), "truncate");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void truncateCollectionShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    kuzzleMock.getCollectionController().truncate(index, collection);
+  }
 }


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `collection:truncate` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data`, a `yellow-taxi` collection with several documents in it.
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class truncateCollection {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            kuzzle.getCollectionController().truncate("nyc-open-data", "yellow-taxi").get();
            
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```
