### PR TITLE
Add collection:getMapping

### DIFF
--- a/doc/3/controllers/collection/get-mapping/index.md
+++ b/doc/3/controllers/collection/get-mapping/index.md
@@ -1,0 +1,33 @@
+---
+code: true
+type: page
+title: getMapping
+description: Return collection mapping
+---
+
+# getMapping
+
+Returns the collection mapping.
+
+<br/>
+
+```java
+public CompletableFuture<ConcurrentHashMap<String, Object>> getMapping(
+      final String index,
+      final String collection) throws NotConnectedException, InternalException
+```
+
+<br/>
+
+| Arguments    | Type              | Description     |
+| ------------ | ----------------- | --------------- |
+| `index`      | <pre>String</pre> | Index name      |
+| `collection` | <pre>String</pre> | Collection name |
+
+## Returns
+
+Returns a `ConcurrentHashMap<String, Object>` representing the collection mapping.
+
+## Usage
+
+<<< ./snippets/get-mapping.js

--- a/doc/3/controllers/collection/get-mapping/snippets/get-mapping.java
+++ b/doc/3/controllers/collection/get-mapping/snippets/get-mapping.java
@@ -1,0 +1,25 @@
+ConcurrentHashMap<String, Object> result = kuzzle
+    .getCollectionController()
+    .getMapping("nyc-open-data", "test")
+    .get();
+
+/*
+{
+  _meta={
+      schema={},
+      allowForm=false
+    },
+    dynamic=true,
+    properties={
+      key={
+        type=text,
+          fields={
+            keyword={
+            ignore_above=256,
+            type=keyword
+            }
+          }
+        }
+      }
+    }
+*/

--- a/doc/3/controllers/collection/get-mapping/snippets/get-mapping.java
+++ b/doc/3/controllers/collection/get-mapping/snippets/get-mapping.java
@@ -1,6 +1,6 @@
 ConcurrentHashMap<String, Object> result = kuzzle
     .getCollectionController()
-    .getMapping("nyc-open-data", "test")
+    .getMapping("nyc-open-data", "yellow-taxi")
     .get();
 
 /*

--- a/doc/3/controllers/collection/get-mapping/snippets/get-mapping.test.yml
+++ b/doc/3/controllers/collection/get-mapping/snippets/get-mapping.test.yml
@@ -1,0 +1,7 @@
+name: collection#getMapping
+description: Return collection mapping
+hooks:
+  before: curl -X POST kuzzle:7512/nyc-open-data/_create && curl -X PUT kuzzle:7512/nyc-open-data/yellow-taxi
+  after:
+template: print-result
+expected: "true"

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -6,6 +6,7 @@ import io.kuzzle.sdk.Exceptions.NotConnectedException;
 import io.kuzzle.sdk.Kuzzle;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class CollectionController extends BaseController {
 
@@ -37,5 +38,31 @@ public class CollectionController extends BaseController {
         .query(query)
         .thenApplyAsync(
             (response) -> (Boolean) response.result);
+  }
+
+  /**
+   * Get collection mapping
+   *
+   * @param index
+   * @param collection
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, Object>> getMapping(
+      final String index,
+      final String collection) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "collection")
+        .put("action", "getMapping");
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (ConcurrentHashMap<String, Object>) response.result);
   }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
@@ -49,4 +49,35 @@ public class CollectionTest {
 
     kuzzleMock.getCollectionController().exists(index, collection);
   }
+
+  @Test
+  public void getMappingCollectionTest() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getCollectionController().getMapping(index, collection);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "collection");
+    assertEquals((arg.getValue()).getString("action"), "getMapping");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void getMappingShouldThrowWhenNotConnected() throws NotConnectedException, InternalException {
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    kuzzleMock.getCollectionController().getMapping(index, collection);
+  }
 }


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `collection:create` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data`, a collection `yellow-taxi`.
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class getMappingCollection {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            ConcurrentHashMap<String, Object> result = kuzzle.getCollectionController().getMapping("nyc-open-data", "yellow-taxi").get();
            
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```
