### PR TITLE
Add collection:updateMapping

### DIFF
--- a/doc/3/controllers/collection/update-mapping/index.md
+++ b/doc/3/controllers/collection/update-mapping/index.md
@@ -1,0 +1,60 @@
+---
+code: true
+type: page
+title: updateMapping
+description: Update the collection mapping
+---
+
+# updateMapping
+
+<SinceBadge version="1.7.1" />
+
+You can define the collection [dynamic mapping policy](/core/2/guides/essentials/database-mappings#dynamic-mapping-policy) by setting the `dynamic` field to the desired value.
+
+You can define [collection additional metadata](/core/2/guides/essentials/database-mappings#collection-metadata) within the `_meta` root field.
+
+<br/>
+
+```java
+  public CompletableFuture<Void> updateMapping(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> mapping)
+```
+
+<br/>
+
+| Arguments    | Type                                         | Description                                                                                                                                                                   |
+| ------------ | -------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `index`      | <pre>String</pre>                            | Index name                                                                                                                                                                    |
+| `collection` | <pre>String</pre>                            | Collection name                                                                                                                                                               |
+| `mapping`    | <pre>ConcurrentHashMap<String, Object></pre> | Describes the collection mapping  |
+
+### mapping
+
+A `ConcurrentHashMap<String, Object>` representing the collection data mapping.
+
+It must have a root field `properties` that contain the mapping definition:
+
+```java
+{
+  properties={
+    field1={ type='text' },
+    field2={
+      properties={
+        nestedField={ type='keyword' }
+      }
+    }
+  }
+};
+```
+
+More information about database mappings [here](/core/2/guides/essentials/database-mappings).
+
+## Returns
+
+Returns a `CompletableFuture<Void>`.
+
+## Usage
+
+<<< ./snippets/update-mapping.java

--- a/doc/3/controllers/collection/update-mapping/snippets/update-mapping.java
+++ b/doc/3/controllers/collection/update-mapping/snippets/update-mapping.java
@@ -1,0 +1,12 @@
+    ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
+
+    license.put("type", "keyword");
+    properties.put("license", license);
+    mapping.put("properties", properties);
+
+    kuzzle
+        .getCollectionController()
+        .updateMapping("nyc-open-data", "yellow-taxi", mapping)
+        .get();

--- a/doc/3/controllers/collection/update-mapping/snippets/update-mapping.test.yml
+++ b/doc/3/controllers/collection/update-mapping/snippets/update-mapping.test.yml
@@ -1,0 +1,7 @@
+name: collection#updateMapping
+description: Update the collection mapping
+hooks:
+  before: curl -X POST kuzzle:7512/nyc-open-data/_create && curl -X PUT kuzzle:7512/nyc-open-data/yellow-taxi
+  after:
+template: default
+expected: Success

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -110,4 +110,34 @@ public class CollectionController extends BaseController {
         .thenApplyAsync(
             (response) -> (ConcurrentHashMap<String, Object>) response.result);
   }
+
+  /**
+   * Updates collection mapping.
+   *
+   * @param index
+   * @param collection
+   * @param mapping
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<Void> updateMapping(
+      final String index,
+      final String collection,
+      final ConcurrentHashMap<String, Object> mapping) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "collection")
+        .put("action", "updateMapping")
+        .put("body", new KuzzleMap(mapping));
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> null);
+  }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
@@ -148,4 +148,60 @@ public class CollectionTest {
 
     kuzzleMock.getCollectionController().getMapping(index, collection);
   }
+
+  @Test
+  public void updateMappingCollectionTest() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
+
+    license.put("type", "keyword");
+    properties.put("license", license);
+    mapping.put("properties", properties);
+
+    kuzzleMock.getCollectionController().updateMapping(index, collection, mapping);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "collection");
+    assertEquals((arg.getValue()).getString("action"), "updateMapping");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+    assertEquals((
+        (ConcurrentHashMap<String, Object>) (
+            (ConcurrentHashMap<String, Object>) (
+                ((ConcurrentHashMap<String, Object>)
+                    ((arg.getValue())
+                        .get("body")))
+                    .get("properties")))
+            .get("license"))
+        .get("type").toString(), "keyword");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void updateMappingCollectionThrowWhenNotConnected() throws NotConnectedException, InternalException {
+
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
+    ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();
+
+    license.put("type", "keyword");
+    properties.put("license", license);
+    mapping.put("properties", properties);
+
+    kuzzleMock.getCollectionController().updateMapping(index, collection, mapping);
+  }
 }


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `collection:updateMapping` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data`, a `yellow-taxi` collection
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class updateMappingCollection {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();
           
            ConcurrentHashMap<String, Object> mapping = new ConcurrentHashMap<>();
            ConcurrentHashMap<String, Object> properties = new ConcurrentHashMap<>();
            ConcurrentHashMap<String, Object> license = new ConcurrentHashMap<>();

            license.put("type", "keyword");
            properties.put("license", license);
            mapping.put("properties", properties);

            kuzzle.getCollectionController().updateMapping("mtp-open-data", "dark-taxi", mapping).get();
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```
