### PR TITLE
Add collection:getSpecifications

### DIFF
--- a/.ci/doc/config.yml
+++ b/.ci/doc/config.yml
@@ -2,7 +2,7 @@
 
 snippets:
   mount: /mnt
-  path: 'doc/**/snippets/validate-specifications.test.yml'
+  path: 'doc/**/snippets/*.test.yml'
   templates: /mnt/.ci/doc/templates
 
 runners:

--- a/.ci/doc/config.yml
+++ b/.ci/doc/config.yml
@@ -2,7 +2,7 @@
 
 snippets:
   mount: /mnt
-  path: 'doc/**/snippets/*.test.yml'
+  path: 'doc/**/snippets/validate-specifications.test.yml'
   templates: /mnt/.ci/doc/templates
 
 runners:

--- a/doc/3/controllers/collection/get-specifications/index.md
+++ b/doc/3/controllers/collection/get-specifications/index.md
@@ -1,0 +1,33 @@
+---
+code: true
+type: page
+title: getSpecifications
+description: Returns the validation specifications
+---
+
+# getSpecifications
+
+Returns the validation specifications associated to the given index and collection.
+
+<br/>
+
+```java
+  public CompletableFuture<ConcurrentHashMap<String, Object>> getSpecifications(
+      final String index,
+      final String collection)
+```
+
+<br/>
+
+| Arguments    | Type              | Description     |
+| ------------ | ----------------- | --------------- |
+| `index`      | <pre>String</pre> | Index name      |
+| `collection` | <pre>String</pre> | Collection name |
+
+## Returns
+
+Returns a `ConcurrentHashMap<String, Object>` representing the collection specifications.
+
+## Usage
+
+<<< ./snippets/get-specifications.java

--- a/doc/3/controllers/collection/get-specifications/snippets/get-specifications.java
+++ b/doc/3/controllers/collection/get-specifications/snippets/get-specifications.java
@@ -1,0 +1,21 @@
+    ConcurrentHashMap<String, Object> result = kuzzle
+        .getCollectionController()
+        .getSpecifications("nyc-open-data", "yellow-taxi")
+        .get();
+
+/*
+  {
+    collection="yellow-taxi",
+    index="nyc-open-data",
+    validation={
+      fields={
+        age={
+          defaultValue=42,
+          mandatory=true,
+          type="integer"
+        }
+      },
+      strict=true
+    }
+  }
+*/

--- a/doc/3/controllers/collection/get-specifications/snippets/get-specifications.test.yml
+++ b/doc/3/controllers/collection/get-specifications/snippets/get-specifications.test.yml
@@ -1,0 +1,11 @@
+name: collection#getSpecifications
+description: Returns the validation specifications
+hooks:
+  before: |
+    curl -X DELETE kuzzle:7512/nyc-open-data
+    curl -X POST kuzzle:7512/nyc-open-data/_create
+    curl -X PUT kuzzle:7512/nyc-open-data/yellow-taxi
+    curl -X PUT -H "Content-Type: application/json" -d '{ "strict": false, "fields": {"license": {"type": "string"} } }' kuzzle:7512/nyc-open-data/yellow-taxi/_specifications
+  after:
+template: print-result
+expected: 'fields'

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -110,4 +110,31 @@ public class CollectionController extends BaseController {
         .thenApplyAsync(
             (response) -> (ConcurrentHashMap<String, Object>) response.result);
   }
+
+  /**
+   * Gets the validation specifications associated to the given index and collection.
+   *
+   * @param index
+   * @param collection
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<ConcurrentHashMap<String, Object>> getSpecifications(
+      final String index,
+      final String collection) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "collection")
+        .put("action", "getSpecifications");
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> (ConcurrentHashMap<String, Object>) response.result);
+  }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
@@ -148,4 +148,35 @@ public class CollectionTest {
 
     kuzzleMock.getCollectionController().getMapping(index, collection);
   }
+
+  @Test
+  public void getSpecificationsCollectionTest() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getCollectionController().getSpecifications(index, collection);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "collection");
+    assertEquals((arg.getValue()).getString("action"), "getSpecifications");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void getSpecificationsCollectionThrowWhenNotConnected() throws NotConnectedException, InternalException {
+
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    kuzzleMock.getCollectionController().getSpecifications(index, collection);
+  }
 }


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `collection:getSpecifications` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data`, a `yellow-taxi` collection
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class getSpecificationsCollection {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            ConcurrentHashMap<String, Object> result = 
            kuzzle.getCollectionController().getSpecifications("nyc-open-data", "yellow-taxi").get();
           
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```

