### PR TITLE
Add collection:deleteSpecifications

### DIFF
--- a/doc/3/controllers/collection/delete-specifications/index.md
+++ b/doc/3/controllers/collection/delete-specifications/index.md
@@ -1,0 +1,33 @@
+---
+code: true
+type: page
+title: deleteSpecifications
+description: Delete validation specifications for a collection
+---
+
+# deleteSpecifications
+
+Deletes validation specifications for a collection.
+
+<br/>
+
+```java
+  public CompletableFuture<Void> deleteSpecifications(
+      final String index,
+      final String collection)
+```
+
+<br/>
+
+| Arguments    | Type              | Description     |
+| ------------ | ----------------- | --------------- |
+| `index`      | <pre>String</pre> | Index name      |
+| `collection` | <pre>String</pre> | Collection name |
+
+## Returns
+
+Returns a `CompletableFuture<Void>`.
+
+## Usage
+
+<<< ./snippets/delete-specifications.java

--- a/doc/3/controllers/collection/delete-specifications/snippets/delete-specifications.java
+++ b/doc/3/controllers/collection/delete-specifications/snippets/delete-specifications.java
@@ -1,0 +1,4 @@
+    kuzzle
+        .getCollectionController()
+        .deleteSpecifications("nyc-open-data", "yellow-taxi")
+        .get();

--- a/doc/3/controllers/collection/delete-specifications/snippets/delete-specifications.test.yml
+++ b/doc/3/controllers/collection/delete-specifications/snippets/delete-specifications.test.yml
@@ -1,0 +1,7 @@
+name: collection#deleteSpecifications
+description: Delete validation specifications for a collection
+hooks:
+  before: curl -X POST kuzzle:7512/nyc-open-data/_create && curl -X PUT kuzzle:7512/nyc-open-data/yellow-taxi
+  after:
+template: default
+expected: Success

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -136,4 +136,31 @@ public class CollectionController extends BaseController {
         .thenApplyAsync(
             (response) -> (ConcurrentHashMap<String, Object>) response.result);
   }
+
+  /**
+   * Deletes the validation specifications associated to the given index and collection.
+   *
+   * @param index
+   * @param collection
+   * @return a CompletableFuture
+   * @throws NotConnectedException
+   * @throws InternalException
+   */
+  public CompletableFuture<Void> deleteSpecifications(
+      final String index,
+      final String collection) throws NotConnectedException, InternalException {
+
+    final KuzzleMap query = new KuzzleMap();
+
+    query
+        .put("index", index)
+        .put("collection", collection)
+        .put("controller", "collection")
+        .put("action", "deleteSpecifications");
+
+    return kuzzle
+        .query(query)
+        .thenApplyAsync(
+            (response) -> null);
+  }
 }

--- a/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
+++ b/src/main/java/io/kuzzle/sdk/API/Controllers/CollectionController.java
@@ -137,30 +137,30 @@ public class CollectionController extends BaseController {
             (response) -> (ConcurrentHashMap<String, Object>) response.result);
   }
 
-  /**
-   * Deletes the validation specifications associated to the given index and collection.
-   *
-   * @param index
-   * @param collection
-   * @return a CompletableFuture
-   * @throws NotConnectedException
-   * @throws InternalException
-   */
-  public CompletableFuture<Void> deleteSpecifications(
-      final String index,
-      final String collection) throws NotConnectedException, InternalException {
-
-    final KuzzleMap query = new KuzzleMap();
-
-    query
-        .put("index", index)
-        .put("collection", collection)
-        .put("controller", "collection")
-        .put("action", "deleteSpecifications");
-
-    return kuzzle
-        .query(query)
-        .thenApplyAsync(
-            (response) -> null);
-  }
+//  /**
+//   * Deletes the validation specifications associated to the given index and collection.
+//   *
+//   * @param index
+//   * @param collection
+//   * @return a CompletableFuture
+//   * @throws NotConnectedException
+//   * @throws InternalException
+//   */
+//  public CompletableFuture<Void> deleteSpecifications(
+//      final String index,
+//      final String collection) throws NotConnectedException, InternalException {
+//
+//    final KuzzleMap query = new KuzzleMap();
+//
+//    query
+//        .put("index", index)
+//        .put("collection", collection)
+//        .put("controller", "collection")
+//        .put("action", "deleteSpecifications");
+//
+//    return kuzzle
+//        .query(query)
+//        .thenApplyAsync(
+//            (response) -> null);
+//  }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
@@ -179,34 +179,34 @@ public class CollectionTest {
     kuzzleMock.getCollectionController().getMapping(index, collection);
   }
 
-  @Test
-  public void deleteSpecificationsCollectionTest() throws NotConnectedException, InternalException {
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
-
-    kuzzleMock.getCollectionController().deleteSpecifications(index, collection);
-    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
-
-    assertEquals((arg.getValue()).getString("controller"), "collection");
-    assertEquals((arg.getValue()).getString("action"), "deleteSpecifications");
-    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
-    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
-  }
-
-  @Test(expected = NotConnectedException.class)
-  public void deleteSpecificationsCollectionThrowWhenNotConnected() throws NotConnectedException, InternalException {
-
-    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
-    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
-
-    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
-    String index = "nyc-open-data";
-    String collection = "yellow-taxi";
-
-    kuzzleMock.getCollectionController().deleteSpecifications(index, collection);
-  }
+//  @Test
+//  public void deleteSpecificationsCollectionTest() throws NotConnectedException, InternalException {
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+//
+//    kuzzleMock.getCollectionController().deleteSpecifications(index, collection);
+//    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+//
+//    assertEquals((arg.getValue()).getString("controller"), "collection");
+//    assertEquals((arg.getValue()).getString("action"), "deleteSpecifications");
+//    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+//    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+//  }
+//
+//  @Test(expected = NotConnectedException.class)
+//  public void deleteSpecificationsCollectionThrowWhenNotConnected() throws NotConnectedException, InternalException {
+//
+//    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+//    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+//
+//    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+//    String index = "nyc-open-data";
+//    String collection = "yellow-taxi";
+//
+//    kuzzleMock.getCollectionController().deleteSpecifications(index, collection);
+//  }
 }

--- a/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
+++ b/src/test/java/io/kuzzle/test/API/Controllers/CollectionTest.java
@@ -178,4 +178,35 @@ public class CollectionTest {
 
     kuzzleMock.getCollectionController().getMapping(index, collection);
   }
+
+  @Test
+  public void deleteSpecificationsCollectionTest() throws NotConnectedException, InternalException {
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(networkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    ArgumentCaptor<KuzzleMap> arg = ArgumentCaptor.forClass(KuzzleMap.class);
+
+    kuzzleMock.getCollectionController().deleteSpecifications(index, collection);
+    Mockito.verify(kuzzleMock, Mockito.times(1)).query(arg.capture());
+
+    assertEquals((arg.getValue()).getString("controller"), "collection");
+    assertEquals((arg.getValue()).getString("action"), "deleteSpecifications");
+    assertEquals((arg.getValue()).getString("index"), "nyc-open-data");
+    assertEquals((arg.getValue()).getString("collection"), "yellow-taxi");
+  }
+
+  @Test(expected = NotConnectedException.class)
+  public void deleteSpecificationsCollectionThrowWhenNotConnected() throws NotConnectedException, InternalException {
+
+    AbstractProtocol fakeNetworkProtocol = Mockito.mock(WebSocket.class);
+    Mockito.when(fakeNetworkProtocol.getState()).thenAnswer((Answer<ProtocolState>) invocation -> ProtocolState.CLOSE);
+
+    Kuzzle kuzzleMock = spy(new Kuzzle(fakeNetworkProtocol));
+    String index = "nyc-open-data";
+    String collection = "yellow-taxi";
+
+    kuzzleMock.getCollectionController().deleteSpecifications(index, collection);
+  }
 }


### PR DESCRIPTION
## What does this PR do ?

This PR implements the `collection:deleteSpecifications` method with its unit tests.

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

### How should this be manually tested?

Clone this branch and run unit tests
`./gradlew test`

When it succeed, compile it

`./gradlew jar`

Initiate another java project by adding the compiled SDK as a dependency.

Then, run Kuzzle, create an index `nyc-open-data`, a `yellow-taxi` collection
Finally, run this code

```java
import io.kuzzle.sdk.*;
import io.kuzzle.sdk.Options.KuzzleOptions;
import io.kuzzle.sdk.Options.Protocol.WebSocketOptions;
import io.kuzzle.sdk.Protocol.WebSocket;

import java.util.concurrent.ConcurrentHashMap;

public class deleteSpecificationsCollection {
    private static Kuzzle kuzzle;

    public static void main(String[] args) {
        WebSocketOptions opts = new WebSocketOptions();
        opts.setAutoReconnect(true).setConnectionTimeout(42000);

        try {
            WebSocket ws = new WebSocket("localhost", opts);

            kuzzle = new Kuzzle(ws, (KuzzleOptions) null);

            kuzzle.connect();

            kuzzle.getCollectionController().deleteSpecifications("nyc-open-data", "yellow-taxi").get();
           
        }  catch (Exception e) {
            e.printStackTrace();
        }

        kuzzle.disconnect();
    }
};
```

