### PR TITLE
[fix] Correctly aim at the right doc snippet files

### DIFF
--- a/doc/3/controllers/collection/get-mapping/index.md
+++ b/doc/3/controllers/collection/get-mapping/index.md
@@ -30,4 +30,4 @@ Returns a `ConcurrentHashMap<String, Object>` representing the collection mappin
 
 ## Usage
 
-<<< ./snippets/get-mapping.js
+<<< ./snippets/get-mapping.java

--- a/doc/3/controllers/collection/truncate/index.md
+++ b/doc/3/controllers/collection/truncate/index.md
@@ -26,4 +26,4 @@ public CompletableFuture<Void> truncate(
 
 ## Usage
 
-<<< ./snippets/truncate.js
+<<< ./snippets/truncate.java

--- a/doc/3/controllers/document/delete-by-query/index.md
+++ b/doc/3/controllers/document/delete-by-query/index.md
@@ -43,4 +43,4 @@ Returns an `ArrayList<String>` containing the deleted document ids.
 
 ## Usage
 
-<<< ./snippets/delete-by-query.js
+<<< ./snippets/delete-by-query.java

--- a/doc/3/controllers/document/update-by-query/index.md
+++ b/doc/3/controllers/document/update-by-query/index.md
@@ -73,4 +73,4 @@ Each errored document is an object of the `errors` array with the following prop
 
 ## Usage
 
-<<< ./snippets/update-by-query.js
+<<< ./snippets/update-by-query.java

--- a/doc/3/controllers/document/update/snippets/update.test.yml
+++ b/doc/3/controllers/document/update/snippets/update.test.yml
@@ -8,4 +8,4 @@ hooks:
     curl -XPOST -d '{"name":"John"}' -H "Content-Type: application/json" kuzzle:7512/nyc-open-data/yellow-taxi/some-id/_create
   after:
 template: print-result
-expected: "{_id=some-id, _version=2}"
+expected: "_id=some-id, _version=2"


### PR DESCRIPTION
## What does this PR do ?
Updated a few doc files to aim the real existing **.java** files, instead of some **.js**

- collection/**get-mapping**
- collection/**truncate**
- document/**delete-by-query**
- document/**update-by-query**

## Current behaviour
![image](https://user-images.githubusercontent.com/2495908/86008042-93361d00-ba18-11ea-96c3-588bb781958a.png)

### How should this be manually tested?

Clone and launch:
`npm install & npm run doc-prepare & npm run doc-build`

You should not see any errors related to missing snippets.

### Boyscout
To get the ci build to succed, had to update [document/update test file](https://github.com/kuzzleio/sdk-java/blob/ad15a06170fa0d69f97b50a34a29705d40510617/doc/3/controllers/document/update/snippets/update.test.yml#L11) to expect:
`'expected: "_id=some-id, _version=2"'`
instead of:
`'{expected: "_id=some-id, _version=2"}'`