### PR TITLE
Fix token expired

### DIFF
--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -197,23 +197,15 @@ public class Kuzzle extends EventManager {
       return;
     }
 
-    if (response.error.id == null
-        || !response.error.id.equals("security.token.expired")) {
-      final Task<Response> task = requests.get(response.requestId);
-      if (task != null) {
-        task.setException(new ApiErrorException(response));
-      }
-      return;
-    }
-
     final Task<Response> task = requests.get(response.requestId);
-
     if (task != null) {
       task.setException(new ApiErrorException(response));
     }
-
     requests.remove(response.requestId);
-    super.trigger(Event.tokenExpired);
+
+    if (response.error.id != null && response.error.id.equals("security.token.expired")) {
+      super.trigger(Event.tokenExpired);
+    }
   }
 
   protected void onStateChanged(final Object... args) {

--- a/src/main/java/io/kuzzle/sdk/Kuzzle.java
+++ b/src/main/java/io/kuzzle/sdk/Kuzzle.java
@@ -206,6 +206,13 @@ public class Kuzzle extends EventManager {
       return;
     }
 
+    final Task<Response> task = requests.get(response.requestId);
+
+    if (task != null) {
+      task.setException(new ApiErrorException(response));
+    }
+
+    requests.remove(response.requestId);
     super.trigger(Event.tokenExpired);
   }
 


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do ?
<!-- Please fill this section -->
- There was an issue where CompletableFutures were not completed  exceptionally when there was a TokenExpired error response, causing java applications using the SDK to be locked when  doing `.get()`  or `.join()` on the resulting Task of a controller action,
because the Future was never resolved.
<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

<!-- Uncomment this section to link PR on other SDKs
https://github.com/kuzzleio/sdk-cpp/pull/ :arrow_left: :large_blue_circle:
-->

